### PR TITLE
Increase tested transfer count and data size

### DIFF
--- a/src/congestion.rs
+++ b/src/congestion.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 pub(crate) const DEFAULT_TARGET_MICROS: u32 = 100_000;
 pub(crate) const DEFAULT_INITIAL_TIMEOUT: Duration = Duration::from_secs(1);
 pub(crate) const DEFAULT_MIN_TIMEOUT: Duration = Duration::from_millis(500);
+pub(crate) const MAX_TIMEOUT: Duration = Duration::from_secs(60);
 pub(crate) const DEFAULT_MAX_PACKET_SIZE_BYTES: u32 = 1024;
 const DEFAULT_GAIN: f32 = 1.0;
 const DEFAULT_DELAY_WINDOW: Duration = Duration::from_secs(120);
@@ -260,7 +261,7 @@ impl Controller {
     /// Registers a timeout with the controller.
     pub fn on_timeout(&mut self) {
         self.max_window_size_bytes = self.min_window_size_bytes;
-        self.timeout *= 2;
+        self.timeout = cmp::min(self.timeout * 2, MAX_TIMEOUT);
     }
 
     /// Adjusts the maximum window (i.e. congestion window) by `adjustment`, keeping the size of

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,9 +1,10 @@
+use std::time::Instant;
 use crate::cid::ConnectionId;
 use crate::packet::Packet;
 
 #[derive(Clone, Debug)]
 pub enum StreamEvent {
-    Incoming(Packet),
+    Incoming(Packet, Instant),
     Shutdown,
 }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::Instant;
 
 use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, oneshot};
@@ -81,13 +82,14 @@ where
 
                         let init_cid = cid_from_packet(&packet, &src, false);
                         let acc_cid = cid_from_packet(&packet, &src, true);
+                        let now = Instant::now();
                         let mut conns = conns.write().unwrap();
                         let conn = conns
                             .get(&acc_cid)
                             .or_else(|| conns.get(&init_cid));
                         match conn {
                             Some(conn) => {
-                                let _ = conn.send(StreamEvent::Incoming(packet));
+                                let _ = conn.send(StreamEvent::Incoming(packet, now));
                             }
                             None => {
                                 if std::matches!(packet.packet_type(), PacketType::Syn) {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -79,7 +79,10 @@ where
                         // data read.
                         buf.reserve(data.len());
                     }
-                    Err(err) => return Err(err),
+                    Err(err) => {
+                        tracing::error!(?self.cid, "read to eof error: {:?}", err);
+                        return Err(err);
+                    }
                 },
                 Err(err) => return Err(io::Error::new(io::ErrorKind::Other, format!("{err:?}"))),
             }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -21,8 +21,8 @@ async fn socket() {
     let mut handles = vec![];
 
     // start 50 transfers, step by two to avoid cid collisions
-    for i in (0..1000).step_by(2) {
-        let handle = initiate_transfer(i, recv_addr, recv.clone(), send_addr, send.clone()).await;
+    for i in 0..20 {
+        let handle = initiate_transfer(i * 2, recv_addr, recv.clone(), send_addr, send.clone()).await;
         handles.push(handle.0);
         handles.push(handle.1);
     }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -21,7 +21,7 @@ async fn socket() {
     let mut handles = vec![];
 
     // start 50 transfers, step by two to avoid cid collisions
-    for i in (0..100).step_by(2) {
+    for i in (0..1000).step_by(2) {
         let handle = initiate_transfer(i, recv_addr, recv.clone(), send_addr, send.clone()).await;
         handles.push(handle.0);
         handles.push(handle.1);

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -7,7 +7,7 @@ use utp_rs::cid;
 use utp_rs::conn::ConnectionConfig;
 use utp_rs::socket::UtpSocket;
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn socket() {
     tracing_subscriber::fmt::init();
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1,6 +1,8 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use tokio::task::JoinHandle;
+
 use utp_rs::cid;
 use utp_rs::conn::ConnectionConfig;
 use utp_rs::socket::UtpSocket;
@@ -9,95 +11,68 @@ use utp_rs::socket::UtpSocket;
 async fn socket() {
     tracing_subscriber::fmt::init();
 
-    let conn_config = ConnectionConfig::default();
-
-    let data_one = vec![0xef; 8192 * 2 * 2];
-    let data_one_recv = data_one.clone();
-
     let recv_addr = SocketAddr::from(([127, 0, 0, 1], 3400));
+    let send_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
+
     let recv = UtpSocket::bind(recv_addr).await.unwrap();
     let recv = Arc::new(recv);
-
-    let send_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
     let send = UtpSocket::bind(send_addr).await.unwrap();
     let send = Arc::new(send);
+    let mut handles = vec![];
 
-    let recv_one_cid = cid::ConnectionId {
-        send: 100,
-        recv: 101,
+    // start 50 transfers, step by two to avoid cid collisions
+    for i in (0..100).step_by(2) {
+        let handle = initiate_transfer(i, recv_addr, recv.clone(), send_addr, send.clone()).await;
+        handles.push(handle.0);
+        handles.push(handle.1);
+    }
+
+    let result = futures::future::join_all(handles).await;
+    for res in result {
+        res.unwrap();
+    }
+}
+
+async fn initiate_transfer(
+    i: u16,
+    recv_addr: SocketAddr,
+    recv: Arc<UtpSocket<SocketAddr>>,
+    send_addr: SocketAddr,
+    send: Arc<UtpSocket<SocketAddr>>,
+) -> (JoinHandle<()>, JoinHandle<()>) {
+    let conn_config = ConnectionConfig::default();
+    let initiator_cid = 100 + i;
+    let responder_cid = 100 + i + 1;
+    let recv_cid = cid::ConnectionId {
+        send: initiator_cid,
+        recv: responder_cid,
         peer: send_addr,
     };
-    let send_one_cid = cid::ConnectionId {
-        send: 101,
-        recv: 100,
+    let send_cid = cid::ConnectionId {
+        send: responder_cid,
+        recv: initiator_cid,
         peer: recv_addr,
     };
 
-    let recv_arc = Arc::clone(&recv);
-    let recv_one_handle = tokio::spawn(async move {
-        let mut stream = recv_arc
-            .accept_with_cid(recv_one_cid, conn_config)
-            .await
-            .unwrap();
+    let data = vec![0xfe; 1_000_000];
+    let data_recv = data.clone();
+
+    let recv_handle = tokio::spawn(async move {
+        let mut stream = recv.accept_with_cid(recv_cid, conn_config).await.unwrap();
         let mut buf = vec![];
         let n = stream.read_to_eof(&mut buf).await.unwrap();
-        tracing::info!(cid.send = %recv_one_cid.send, cid.recv = %recv_one_cid.recv, "read {n} bytes from uTP stream");
+        tracing::info!(cid.send = %recv_cid.send, cid.recv = %recv_cid.recv, "read {n} bytes from uTP stream");
 
-        assert_eq!(n, data_one_recv.len());
-        assert_eq!(buf, data_one_recv);
+        assert_eq!(n, data_recv.len());
+        assert_eq!(buf, data_recv);
     });
 
-    let send_arc = Arc::clone(&send);
-    tokio::spawn(async move {
-        let mut stream = send_arc
-            .connect_with_cid(send_one_cid, conn_config)
-            .await
-            .unwrap();
-        let n = stream.write(&data_one).await.unwrap();
-        assert_eq!(n, data_one.len());
+    let send_handle = tokio::spawn(async move {
+        let mut stream = send.connect_with_cid(send_cid, conn_config).await.unwrap();
+        let n = stream.write(&data).await.unwrap();
+        assert_eq!(n, data.len());
 
-        let _ = stream.shutdown();
+        stream.shutdown().unwrap();
     });
-
-    let data_two = vec![0xfe; 8192 * 2 * 2];
-    let data_two_recv = data_two.clone();
-
-    let recv_two_cid = cid::ConnectionId {
-        send: 200,
-        recv: 201,
-        peer: send_addr,
-    };
-    let send_two_cid = cid::ConnectionId {
-        send: 201,
-        recv: 200,
-        peer: recv_addr,
-    };
-
-    let recv_two_handle = tokio::spawn(async move {
-        let mut stream = recv
-            .accept_with_cid(recv_two_cid, conn_config)
-            .await
-            .unwrap();
-        let mut buf = vec![];
-        let n = stream.read_to_eof(&mut buf).await.unwrap();
-        tracing::info!(cid.send = %recv_two_cid.send, cid.recv = %recv_two_cid.recv, "read {n} bytes from uTP stream");
-
-        assert_eq!(n, data_two_recv.len());
-        assert_eq!(buf, data_two_recv);
-    });
-
-    tokio::spawn(async move {
-        let mut stream = send
-            .connect_with_cid(send_two_cid, conn_config)
-            .await
-            .unwrap();
-        let n = stream.write(&data_two).await.unwrap();
-        assert_eq!(n, data_two.len());
-
-        let _ = stream.shutdown();
-    });
-
-    let (one, two) = tokio::join!(recv_one_handle, recv_two_handle);
-    one.unwrap();
-    two.unwrap();
+    (send_handle, recv_handle)
 }


### PR DESCRIPTION
Ok, well I think I've been able to track down at least one of the degenerative states we've been experiencing w/ utp inside trin. But, first a little context...

- During some debugging with @mrferris yesterday, we were observing not a single `fin` packet being sent from the sender -> receiver. This behavior persisted. Until for an unrelated reason, I restarted my terminal and we started to observe fin packets being sent. I have no explanation for this :shrug:
- However, after this, we still observe degenerative behavior when running a bridge node against a single trin node. I'd estimate that ~30% of accept'ed content actually completes the offer/accept flow. Though, if we gossip only headers (eg relatively small data chunks) then we see 100% successful completes. Once we start gossiping bodies / receipts (eg relatively large data chunks) then we start to see the degenerative state. This implies that there is some bug when running many concurrent utp transfers. 

I've updated the `socket` test to initiate 50 offer/accept flows for a relatively large piece of data. The error message here is familiar from the ones we've been seeing while debugging the live testnet. I'm happy to continue debugging this test failure and find the cause, but some input from @jacobkaufmann first would be nice to confirm that the test is correctly formed and that you can duplicate the failure. 