### PR TITLE
docs: add 'under construction' banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # utp
 A Rust library for the [uTorrent transport protocol (uTP)](https://www.bittorrent.org/beps/bep_0029.html).
 
+## 🚧 WARNING: UNDER CONSTRUCTION 🚧
+This library is currently unstable, with known issues. Use at your own discretion.
+
 # Usage
 
 ```rust


### PR DESCRIPTION
fixes https://github.com/ethereum/utp/issues/48

Emila asked me to make a PR for this. The warning is based off reth's warning, but with a minimal clear description.

Arguments for it are given in the issue linked above and during the call on 5/22/2023. If a library isn't stable it is good practice to give a warning regardless since you never know who will try to use it.