### PR TITLE
Debug stream

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -165,7 +165,7 @@ mod test {
         let config = ConnectionConfig::default();
 
         // write 100k bytes data to the remote peer over the stream.
-        let data = vec![0xed; 1000_000];
+        let data = vec![0xed; 1_000_000];
         let rx_handle = tokio::spawn(async move {
             receiver.accept(config).await.unwrap();
         });

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -119,3 +119,35 @@ impl<P> Drop for UtpStream<P> {
         let _ = self.shutdown();
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::conn::ConnectionConfig;
+    use crate::socket::UtpSocket;
+    use std::net::SocketAddr;
+    #[tokio::test]
+    async fn test_transfer_100k_bytes() {
+        // set-up test
+        let sender_addr = SocketAddr::from(([127, 0, 0, 1], 3400));
+        let receiver_address = SocketAddr::from(([127, 0, 0, 1], 3401));
+        let config = ConnectionConfig::default();
+        let sender = UtpSocket::bind(sender_addr).await.unwrap();
+        let receiver = UtpSocket::bind(receiver_address).await.unwrap();
+        let mut tx_stream = sender.connect(receiver_address, config).await.unwrap();
+        let mut rx_stream = receiver.accept(config).await.unwrap();
+
+        // write 100k bytes data to the remote peer over the stream.
+        let data = vec![0xef; 100_000];
+        tx_stream
+            .write(data.as_slice())
+            .await
+            .expect("Should send 100k bytes");
+
+        // read data from the remote peer until the peer indicates there is no data left to write.
+        let mut data = vec![];
+        rx_stream
+            .read_to_eof(&mut data)
+            .await
+            .expect("Should receive 100k bytes");
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -128,26 +128,27 @@ mod test {
     #[tokio::test]
     async fn test_transfer_100k_bytes() {
         // set-up test
+        tracing_subscriber::fmt::init();
         let sender_addr = SocketAddr::from(([127, 0, 0, 1], 3400));
-        let receiver_address = SocketAddr::from(([127, 0, 0, 1], 3401));
-        let config = ConnectionConfig::default();
+        let receiver_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
+
         let sender = UtpSocket::bind(sender_addr).await.unwrap();
-        let receiver = UtpSocket::bind(receiver_address).await.unwrap();
-        let mut tx_stream = sender.connect(receiver_address, config).await.unwrap();
-        let mut rx_stream = receiver.accept(config).await.unwrap();
+        let receiver = UtpSocket::bind(receiver_addr).await.unwrap();
+
+        let config = ConnectionConfig::default();
 
         // write 100k bytes data to the remote peer over the stream.
         let data = vec![0xef; 100_000];
+        let rx_handle = tokio::spawn(async move {
+            receiver.accept(config).await.unwrap();
+        });
+
+        let mut tx_stream = sender.connect(receiver_addr, config).await.unwrap();
         tx_stream
             .write(data.as_slice())
             .await
             .expect("Should send 100k bytes");
 
-        // read data from the remote peer until the peer indicates there is no data left to write.
-        let mut data = vec![];
-        rx_stream
-            .read_to_eof(&mut data)
-            .await
-            .expect("Should receive 100k bytes");
+        rx_handle.await.unwrap();
     }
 }


### PR DESCRIPTION
On my MacBook Air M1 I can transfer 1 million bytes no problem. When I try to transfer 2 million bytes I get this error when running on my branch _error-handling_ `thread 'stream::test::test_transfer_2m_bytes' panicked at 'Should send 1m bytes: Conn(ConnClosed("idle uTP connection time out"))'`. This closes https://github.com/ethereum/utp/issues/44, possibly in place of a new issue.