### PR TITLE
Fix FIN not sent bug

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -119,3 +119,125 @@ impl<P> Drop for UtpStream<P> {
         let _ = self.shutdown();
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::conn::ConnectionConfig;
+    use crate::socket::UtpSocket;
+    use std::net::SocketAddr;
+    #[tokio::test]
+    async fn test_transfer_100k_bytes() {
+        // set-up test
+        _ = tracing_subscriber::fmt::try_init();
+        let sender_addr = SocketAddr::from(([127, 0, 0, 1], 3500));
+        let receiver_addr = SocketAddr::from(([127, 0, 0, 1], 3501));
+        // open two peer uTP sockets
+        let sender = UtpSocket::bind(sender_addr).await.unwrap();
+        let receiver = UtpSocket::bind(receiver_addr).await.unwrap();
+        let config = ConnectionConfig::default();
+
+        let rx = async move {
+            // accept connection
+            let mut rx_stream = receiver.accept(config).await.expect("Should accept stream");
+            // read data from the remote peer until the peer indicates there is no data left to
+            // write.
+            let mut data = vec![];
+            rx_stream
+                .read_to_eof(&mut data)
+                .await
+                .expect("Should read 100k bytes")
+        };
+
+        let tx = async move {
+            // initiate connection to peer
+            let mut tx_stream = sender
+                .connect(receiver_addr, config)
+                .await
+                .expect("Should open stream");
+            // write 100k bytes data to the remote peer over the stream.
+            let data = vec![0xef; 100_000];
+            tx_stream
+                .write(data.as_slice())
+                .await
+                .expect("Should send 100k bytes")
+        };
+
+        let (tx_res, rx_res) = tokio::join!(tx, rx);
+
+        assert_eq!(tx_res, rx_res);
+    }
+
+    #[tokio::test]
+    async fn test_transfer_100k_bytes_two() {
+        // set-up test
+        _ = tracing_subscriber::fmt::try_init();
+        let sender_addr = SocketAddr::from(([127, 0, 0, 1], 3502));
+        let receiver_addr = SocketAddr::from(([127, 0, 0, 1], 3503));
+        // open two peer uTP sockets
+        let sender = UtpSocket::bind(sender_addr).await.unwrap();
+        let receiver = UtpSocket::bind(receiver_addr).await.unwrap();
+        let config = ConnectionConfig::default();
+
+        // initiate connection to peer
+        let tx_conn = sender.connect(receiver_addr, config);
+        // accept connection
+        let rx_conn = receiver.accept(config);
+
+        let (tx_stream, rx_stream) = tokio::join!(tx_conn, rx_conn);
+
+        let mut tx_stream = tx_stream.expect("Should open stream");
+        let mut rx_stream = rx_stream.expect("Should accept stream");
+
+        // write 100k bytes data to the remote peer over the stream.
+        let data = vec![0xef; 1_00_000];
+        let tx = tx_stream.write(data.as_slice());
+
+        // read data from the remote peer until the peer indicates there is no data left to write.
+        let mut data = vec![];
+        let rx = rx_stream.read_to_eof(&mut data);
+
+        let (tx_res, rx_res) = tokio::join!(tx, rx);
+
+        let sent = tx_res.expect("Should write 100k bytes");
+        let received = rx_res.expect("Should read 100k bytes");
+
+        assert_eq!(sent, received);
+    }
+
+    #[tokio::test]
+    async fn test_transfer_1_megabyte() {
+        // set-up test
+        _ = tracing_subscriber::fmt::try_init();
+        let sender_addr = SocketAddr::from(([127, 0, 0, 1], 3502));
+        let receiver_addr = SocketAddr::from(([127, 0, 0, 1], 3503));
+        // open two peer uTP sockets
+        let sender = UtpSocket::bind(sender_addr).await.unwrap();
+        let receiver = UtpSocket::bind(receiver_addr).await.unwrap();
+        let config = ConnectionConfig::default();
+
+        // initiate connection to peer
+        let tx_conn = sender.connect(receiver_addr, config);
+        // accept connection
+        let rx_conn = receiver.accept(config);
+
+        let (tx_stream, rx_stream) = tokio::join!(tx_conn, rx_conn);
+
+        let mut tx_stream = tx_stream.expect("Should open stream");
+        let mut rx_stream = rx_stream.expect("Should accept stream");
+
+        // write 100k bytes data to the remote peer over the stream.
+        let data = vec![0xef; 1_000_000];
+        let tx = tx_stream.write(data.as_slice());
+
+        // read data from the remote peer until the peer indicates there is no data left to write.
+        let mut data = vec![];
+        let rx = rx_stream.read_to_eof(&mut data);
+
+        let (tx_res, rx_res) = tokio::join!(tx, rx);
+
+        let sent = tx_res.expect("Should write 100k bytes");
+        let received = rx_res.expect("Should read 100k bytes");
+
+        assert_eq!(sent, received);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/ethereum/utp/issues/44.

A read doesn't complete until a write completes. A write doesn't complete unless a FIN is sent. A FIN is sent when the stream shuts down, hence it should be included in the `write` public function. Furthermore, one stream maps to one connection and therefore it makes no sense to keep the the reading stream open when the write stream is shut down, hence I have included shutdown in `read_to_eof` too.