### PR TITLE
Add current limitation of transfers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This library is currently unstable, with known issues. Use at your own discretio
 
 # Usage
 
+A stream can transfer 1 MB. For larger transfers, data must be chunked to 1 MB chunks and each
+chunk sent on its own stream.
+
 ```rust
 use std::net::SocketAddr;
 


### PR DESCRIPTION
Currently transfer are limited to 1 MB per stream. This is due to the sequence number of the ACK in the packet header being a `u16` as pointed out [here by @KolbyML ](https://github.com/ethereum/utp/pull/62) so even when data larger than the buffer is chunked as [I have added here](https://github.com/ethereum/utp/pull/65), we can't send more than 1 MB. Removing the limit on the send buffer we can send 10 MB, as pointed out [here by @KolbyML](https://github.com/ethereum/utp/pull/56), then the bytes per ACK are limited by the [max packet size](https://github.com/ethereum/utp/blob/a2b619d2b48df347af7ff305d8022caf887868a1/src/congestion.rs#L44). Anyhow, the program should make do with the ACKs it has to send packets as small as 150 bytes: ["In order to have as little impact as possible on slow congested links, uTP adjusts its packet size down to as small as 150 bytes per packet"](https://www.bittorrent.org/beps/bep_0029.html) which is far less than the [current default max packet size](https://github.com/ethereum/utp/blob/a2b619d2b48df347af7ff305d8022caf887868a1/src/congestion.rs#L8). This may be fixed in the near future, but for now this is a known limitation and should be included in README to help others use this crate.