### PR TITLE
limit congestion control timeout amplification

### DIFF
--- a/src/congestion.rs
+++ b/src/congestion.rs
@@ -687,12 +687,12 @@ mod tests {
 
         #[test]
         fn on_timeout_not_exceed_max() {
-            const INITIAL_TIMEOUT: Duration = Duration::from_secs(2);
             const MAX_TIMEOUT: Duration = Duration::from_secs(3);
-
-            let mut config = Config::default();
-            config.initial_timeout = INITIAL_TIMEOUT;
-            config.max_timeout = MAX_TIMEOUT;
+            let config = Config {
+                initial_timeout: Duration::from_secs(2),
+                max_timeout: MAX_TIMEOUT,
+                ..Default::default()
+            };
 
             let mut ctrl = Controller::new(config);
 

--- a/src/congestion.rs
+++ b/src/congestion.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 pub(crate) const DEFAULT_TARGET_MICROS: u32 = 100_000;
 pub(crate) const DEFAULT_INITIAL_TIMEOUT: Duration = Duration::from_secs(1);
 pub(crate) const DEFAULT_MIN_TIMEOUT: Duration = Duration::from_millis(500);
+pub(crate) const DEFAULT_MAX_TIMEOUT: Duration = Duration::from_secs(60);
 pub(crate) const DEFAULT_MAX_PACKET_SIZE_BYTES: u32 = 1024;
 const DEFAULT_GAIN: f32 = 1.0;
 const DEFAULT_DELAY_WINDOW: Duration = Duration::from_secs(120);
@@ -41,6 +42,7 @@ pub struct Config {
     pub target_delay_micros: u32,
     pub initial_timeout: Duration,
     pub min_timeout: Duration,
+    pub max_timeout: Duration,
     pub max_packet_size_bytes: u32,
     pub max_window_size_inc_bytes: u32,
     pub gain: f32,
@@ -53,6 +55,7 @@ impl Default for Config {
             target_delay_micros: DEFAULT_TARGET_MICROS,
             initial_timeout: DEFAULT_INITIAL_TIMEOUT,
             min_timeout: DEFAULT_MIN_TIMEOUT,
+            max_timeout: DEFAULT_MAX_TIMEOUT,
             max_packet_size_bytes: DEFAULT_MAX_PACKET_SIZE_BYTES,
             max_window_size_inc_bytes: DEFAULT_MAX_PACKET_SIZE_BYTES,
             gain: DEFAULT_GAIN,
@@ -66,6 +69,7 @@ pub struct Controller {
     target_delay_micros: u32,
     timeout: Duration,
     min_timeout: Duration,
+    max_timeout: Duration,
     window_size_bytes: u32,
     max_window_size_bytes: u32,
     min_window_size_bytes: u32,
@@ -84,6 +88,7 @@ impl Controller {
             target_delay_micros: config.target_delay_micros,
             timeout: config.initial_timeout,
             min_timeout: config.min_timeout,
+            max_timeout: config.max_timeout,
             window_size_bytes: 0,
             max_window_size_bytes: 2 * config.max_packet_size_bytes,
             min_window_size_bytes: 2 * config.max_packet_size_bytes,
@@ -260,7 +265,7 @@ impl Controller {
     /// Registers a timeout with the controller.
     pub fn on_timeout(&mut self) {
         self.max_window_size_bytes = self.min_window_size_bytes;
-        self.timeout *= 2;
+        self.timeout = cmp::min(self.timeout * 2, self.max_timeout);
     }
 
     /// Adjusts the maximum window (i.e. congestion window) by `adjustment`, keeping the size of
@@ -288,10 +293,14 @@ impl Controller {
     ///
     /// The congestion timeout cannot fall below the configured minimum.
     fn apply_timeout_adjustment(&mut self) {
+        // Do not let timeout go below minimum.
         self.timeout = cmp::max(
             self.rtt + Duration::from_micros(self.rtt_variance_micros * 4),
             self.min_timeout,
         );
+
+        // Do not let timeout go above maximum.
+        self.timeout = cmp::min(self.timeout, self.max_timeout)
     }
 }
 
@@ -674,6 +683,22 @@ mod tests {
             ctrl.on_timeout();
             assert_eq!(ctrl.max_window_size_bytes, ctrl.min_window_size_bytes);
             assert_eq!(ctrl.timeout, initial_timeout * 2);
+        }
+
+        #[test]
+        fn on_timeout_not_exceed_max() {
+            const INITIAL_TIMEOUT: Duration = Duration::from_secs(2);
+            const MAX_TIMEOUT: Duration = Duration::from_secs(3);
+
+            let mut config = Config::default();
+            config.initial_timeout = INITIAL_TIMEOUT;
+            config.max_timeout = MAX_TIMEOUT;
+
+            let mut ctrl = Controller::new(config);
+
+            // Register a timeout.
+            ctrl.on_timeout();
+            assert_eq!(ctrl.timeout, MAX_TIMEOUT);
         }
     }
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -95,6 +95,7 @@ pub struct ConnectionConfig {
     pub max_idle_timeout: Duration,
     pub initial_timeout: Duration,
     pub min_timeout: Duration,
+    pub max_timeout: Duration,
     pub target_delay: Duration,
 }
 
@@ -106,6 +107,7 @@ impl Default for ConnectionConfig {
             max_packet_size: congestion::DEFAULT_MAX_PACKET_SIZE_BYTES as u16,
             initial_timeout: congestion::DEFAULT_INITIAL_TIMEOUT,
             min_timeout: congestion::DEFAULT_MIN_TIMEOUT,
+            max_timeout: congestion::DEFAULT_MAX_TIMEOUT,
             target_delay: Duration::from_micros(congestion::DEFAULT_TARGET_MICROS.into()),
         }
     }
@@ -117,6 +119,7 @@ impl From<ConnectionConfig> for congestion::Config {
             max_packet_size_bytes: u32::from(value.max_packet_size),
             initial_timeout: value.initial_timeout,
             min_timeout: value.min_timeout,
+            max_timeout: value.max_timeout,
             target_delay_micros: value.target_delay.as_micros() as u32,
             ..Default::default()
         }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -101,13 +101,14 @@ pub struct ConnectionConfig {
 
 impl Default for ConnectionConfig {
     fn default() -> Self {
+        let max_idle_timeout = Duration::from_secs(10);
         Self {
             max_conn_attempts: 3,
-            max_idle_timeout: Duration::from_secs(10),
+            max_idle_timeout,
             max_packet_size: congestion::DEFAULT_MAX_PACKET_SIZE_BYTES as u16,
             initial_timeout: congestion::DEFAULT_INITIAL_TIMEOUT,
             min_timeout: congestion::DEFAULT_MIN_TIMEOUT,
-            max_timeout: congestion::DEFAULT_MAX_TIMEOUT,
+            max_timeout: max_idle_timeout,
             target_delay: Duration::from_micros(congestion::DEFAULT_TARGET_MICROS.into()),
         }
     }


### PR DESCRIPTION
we have observed that the congestion control timeout can amplify quickly to the point where the timeout becomes not so useful. for example, the timeout should not exceed the maximum idle timeout.

summary:

* add a maximum timeout field to congestion control
* limit the number of timeouts registered with congestion control by the connection
* add a maximum timeout field to the connection config
  * by default, this value is equal to the max idle timeout