### PR TITLE
Prevent invalid ids being used with connect_with_cid/accept_with_cid

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -225,9 +225,16 @@ where
 
     pub async fn accept_with_cid(
         &self,
-        cid: ConnectionId<P>,
+        cid_recv: u16,
+        cid_peer: P,
         config: ConnectionConfig,
     ) -> io::Result<UtpStream<P>> {
+        let cid = ConnectionId {
+            send: cid_recv.wrapping_sub(1),
+            recv: cid_recv,
+            peer: cid_peer,
+        };
+
         let (stream_tx, stream_rx) = oneshot::channel();
         let accept = Accept {
             stream: stream_tx,
@@ -269,9 +276,16 @@ where
 
     pub async fn connect_with_cid(
         &self,
-        cid: ConnectionId<P>,
+        cid_send: u16,
+        cid_peer: P,
         config: ConnectionConfig,
     ) -> io::Result<UtpStream<P>> {
+        let cid = ConnectionId {
+            send: cid_send,
+            recv: cid_send.wrapping_sub(1),
+            peer: cid_peer,
+        };
+
         if self.conns.read().unwrap().contains_key(&cid) {
             return Err(io::Error::new(
                 io::ErrorKind::Other,


### PR DESCRIPTION
for initiator if cid.recv.wrappingadd(1) != cid.send

It is an invalid cid configuration and will cause other clients to reset. Since this is invalid use of the library we should throw an error if someone tries to use an invalid cid configuration.


I also added the inverse case for ``accept_with_cid``