### PR TITLE
fix: reorder arithmetic in SendBuffer::available to prevent overflow

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -29,7 +29,7 @@ impl<const N: usize> SendBuffer<N> {
 
     /// Returns the number of bytes available in the buffer.
     pub fn available(&self) -> usize {
-        N - self.pending.iter().fold(0, |acc, x| acc + x.len()) + self.offset
+        N + self.offset - self.pending.iter().fold(0, |acc, x| acc + x.len())
     }
 
     /// Returns `true` if the buffer is empty.


### PR DESCRIPTION
available overflows in ``send.rs`` since the add for the offset is done after (I verified this testing local and this fixing it).

superedes https://github.com/ethereum/utp/pull/66 since the review process never got resolved, it has been 2 weeks without a response from pr 66's author, and this overflow bug is an annoying distraction well testing other problems so it would be nice to get it merged.