### PR TITLE
Added tracing::trace!() for "Write data"/"Received packet"

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -689,6 +689,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
     }
 
     fn on_packet(&mut self, packet: &Packet, now: Instant) {
+        tracing::trace!("Received {:?}", packet);
         let now_micros = crate::time::now_micros();
         self.peer_recv_window = packet.window_size();
 
@@ -1103,6 +1104,14 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                 packet.payload().len() as u32,
             )
         };
+        tracing::trace!(
+            "Write data cid={} packetType={} pkSeqNr={} pkAckNr={} length={}",
+            packet.conn_id(),
+            packet.packet_type(),
+            packet.seq_num(),
+            packet.ack_num(),
+            packet.encoded_len()
+        );
 
         sent_packets.on_transmit(packet.seq_num(), packet.packet_type(), payload, len, now);
         unacked.insert_at(packet.seq_num(), packet.clone(), sent_packets.timeout());

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::fmt::{Debug, Formatter};
 
 /// Size of an encoded uTP header in bytes.
 const PACKET_HEADER_LEN: usize = 20;
@@ -129,6 +130,20 @@ pub enum PacketType {
     State,
     Reset,
     Syn,
+}
+
+impl fmt::Display for PacketType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Data => "ST_DATA".to_string(),
+            Self::Fin => "ST_FIN".to_string(),
+            Self::State => "ST_STATE".to_string(),
+            Self::Reset => "ST_RESET".to_string(),
+            Self::Syn => "ST_SYN".to_string(),
+        };
+
+        write!(f, "{s}")
+    }
 }
 
 impl TryFrom<u8> for PacketType {
@@ -404,7 +419,7 @@ impl SelectiveAck {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Packet {
     header: PacketHeader,
     selective_ack: Option<SelectiveAck>,
@@ -551,6 +566,20 @@ impl Packet {
         }
 
         Ok((extensions, index))
+    }
+}
+
+impl Debug for Packet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "packet cid={} packetType={} seqNr={} ackNr={} timestamp={} timestampDiff={} remoteWindow={}",
+               self.conn_id(),
+               self.packet_type(),
+               self.seq_num(),
+               self.ack_num(),
+               self.ts_micros(),
+               self.ts_diff_micros(),
+               self.window_size(),
+        )
     }
 }
 


### PR DESCRIPTION
I added debug traces for "Write data"/"Received packet". Because when I am debugging it is hard to tell if nodes are even sending anything or receiving anything.

These longs are simliar to what fluffy/utp and bittorrent/libutp