### PR TITLE
Allow for mutable state in Socket send/recv

### DIFF
--- a/src/udp.rs
+++ b/src/udp.rs
@@ -10,18 +10,35 @@ use crate::cid::ConnectionPeer;
 #[async_trait]
 pub trait AsyncUdpSocket<P: ConnectionPeer>: Send + Sync {
     /// Attempts to send data on the socket to a given address.
-    async fn send_to(&self, buf: &[u8], target: &P) -> io::Result<usize>;
+    /// Note that this should return nearly immediately, rather than awaiting something internally.
+    async fn send(&mut self, buf: &[u8], target: &P) -> io::Result<usize>;
     /// Attempts to receive a single datagram on the socket.
-    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, P)>;
+    async fn recv(&mut self, buf: &mut [u8]) -> io::Result<(usize, P)>;
 }
+
+
+// If we want to support send() implementations using await that takes a while internally, we
+// probably have to split the sender and receiver into two separate structs. This is because
+// we move the socket into the loop that listens for received state (in src/socket.rs), but if
+// sending waits, then we need it in a separate loop that sends packets. We can move the sender
+// into one spawned loop, and the receiver into another.
+//
+// This first came up when writing a test with a "perfect" link implementing the socket with a
+// bounded channel that gets awaited when sending. That caused the socket event loop to hang and
+// never recover.
+//
+// Note that if we take this approach, we need to do some work to make sure that we are still
+// biasing in favor of reads over rights, possibly by keeping the reads/writes in the same loop,
+// but putting the writes into another channel that's handled in a separate spawned loop. That
+// would serve to bias the reads over writes, but still smoothly handle writes that take a while.
 
 #[async_trait]
 impl AsyncUdpSocket<SocketAddr> for UdpSocket {
-    async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
-        self.send_to(buf, *target).await
+    async fn send(&mut self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
+        self.send_to(buf, target).await
     }
 
-    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+    async fn recv(&mut self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.recv_from(buf).await
     }
 }


### PR DESCRIPTION
Use `&mut self` in send and receive methods.

This allows Socket implementations to use local mutable state when handling send and receive. This is a common need, in testing  and trin. In testing I implemented a "perfect link" using a channel, which was way easier with this change.

The UdpSocket implementation got confused and did infinite recursion (tests started to give a stack overflow). I have some intuition about why, but didn't investigate further. Changing the method names solved the problem.

See where this would be helpful in trin:
https://github.com/ethereum/trin/blob/e4f434f92b576f22a571eb37353313854224f744/portalnet/src/discovery.rs#L281C1-L286