### PR TITLE
test: run 2k concurrent transfers with 1MB of data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,8 @@ tracing = { version = "0.1.37", features = ["std", "attributes", "log"] }
 
 [dev-dependencies]
 quickcheck = "1.0.3"
-tracing-subscriber = "0.3.16"
 tokio = { version = "1.25.0", features = ["test-util"] }
+tracing-subscriber = "0.3.16"
+
+[profile.test]
+opt-level = 3

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1,105 +1,96 @@
+use futures::stream::{FuturesUnordered, StreamExt};
 use std::net::SocketAddr;
 use std::sync::Arc;
+
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
 
 use utp_rs::cid;
 use utp_rs::conn::ConnectionConfig;
 use utp_rs::socket::UtpSocket;
 
-#[tokio::test(flavor = "multi_thread")]
+const TEST_DATA: &[u8] = &[0xf0; 1_000_000];
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 16)]
 async fn socket() {
     tracing_subscriber::fmt::init();
 
-    let conn_config = ConnectionConfig::default();
-
-    let data_one = vec![0xef; 8192 * 2 * 2];
-    let data_one_recv = data_one.clone();
+    tracing::info!("starting socket test");
 
     let recv_addr = SocketAddr::from(([127, 0, 0, 1], 3400));
+    let send_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
+
     let recv = UtpSocket::bind(recv_addr).await.unwrap();
     let recv = Arc::new(recv);
-
-    let send_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
     let send = UtpSocket::bind(send_addr).await.unwrap();
     let send = Arc::new(send);
+    let mut handles = FuturesUnordered::new();
 
-    let recv_one_cid = cid::ConnectionId {
-        send: 100,
-        recv: 101,
+    let start = Instant::now();
+    let num_transfers = 2000;
+    for i in 0..num_transfers {
+        // step up cid by two to avoid collisions
+        let handle =
+            initiate_transfer(i * 2, recv_addr, recv.clone(), send_addr, send.clone()).await;
+        handles.push(handle.0);
+        handles.push(handle.1);
+    }
+
+    while let Some(res) = handles.next().await {
+        res.unwrap();
+    }
+    let elapsed = Instant::now() - start;
+    let megabits_sent = num_transfers as f64 * TEST_DATA.len() as f64 * 8.0 / 1_000_000.0;
+    let transfer_rate = megabits_sent / elapsed.as_secs_f64();
+    tracing::info!("finished real udp load test of {} simultaneous transfers, in {:?}, at a rate of {:.0} Mbps", num_transfers, elapsed, transfer_rate);
+}
+
+async fn initiate_transfer(
+    i: u16,
+    recv_addr: SocketAddr,
+    recv: Arc<UtpSocket<SocketAddr>>,
+    send_addr: SocketAddr,
+    send: Arc<UtpSocket<SocketAddr>>,
+) -> (JoinHandle<()>, JoinHandle<()>) {
+    let conn_config = ConnectionConfig::default();
+    let initiator_cid = 100 + i;
+    let responder_cid = 100 + i + 1;
+    let recv_cid = cid::ConnectionId {
+        send: initiator_cid,
+        recv: responder_cid,
         peer: send_addr,
     };
-    let send_one_cid = cid::ConnectionId {
-        send: 101,
-        recv: 100,
+    let send_cid = cid::ConnectionId {
+        send: responder_cid,
+        recv: initiator_cid,
         peer: recv_addr,
     };
 
-    let recv_arc = Arc::clone(&recv);
-    let recv_one_handle = tokio::spawn(async move {
-        let mut stream = recv_arc
-            .accept_with_cid(recv_one_cid, conn_config)
-            .await
-            .unwrap();
+    let recv_handle = tokio::spawn(async move {
+        let mut stream = recv.accept_with_cid(recv_cid, conn_config).await.unwrap();
         let mut buf = vec![];
-        let n = stream.read_to_eof(&mut buf).await.unwrap();
-        tracing::info!(cid.send = %recv_one_cid.send, cid.recv = %recv_one_cid.recv, "read {n} bytes from uTP stream");
+        let n = match stream.read_to_eof(&mut buf).await {
+            Ok(num_bytes) => num_bytes,
+            Err(err) => {
+                let cid = stream.cid();
+                tracing::error!(?cid, "read to eof error: {:?}", err);
+                panic!("fail to read data");
+            }
+        };
+        tracing::info!(cid.send = %recv_cid.send, cid.recv = %recv_cid.recv, "read {n} bytes from uTP stream");
 
-        assert_eq!(n, data_one_recv.len());
-        assert_eq!(buf, data_one_recv);
+        assert_eq!(n, TEST_DATA.len());
+        assert_eq!(buf, TEST_DATA);
     });
 
-    let send_arc = Arc::clone(&send);
-    tokio::spawn(async move {
-        let mut stream = send_arc
-            .connect_with_cid(send_one_cid, conn_config)
-            .await
-            .unwrap();
-        let n = stream.write(&data_one).await.unwrap();
-        assert_eq!(n, data_one.len());
+    let send_handle = tokio::spawn(async move {
+        let mut stream = send.connect_with_cid(send_cid, conn_config).await.unwrap();
+        let n = stream.write(TEST_DATA).await.unwrap();
+        assert_eq!(n, TEST_DATA.len());
 
-        let _ = stream.close().await;
+        stream.close().await.unwrap();
     });
-
-    let data_two = vec![0xfe; 8192 * 2 * 2];
-    let data_two_recv = data_two.clone();
-
-    let recv_two_cid = cid::ConnectionId {
-        send: 200,
-        recv: 201,
-        peer: send_addr,
-    };
-    let send_two_cid = cid::ConnectionId {
-        send: 201,
-        recv: 200,
-        peer: recv_addr,
-    };
-
-    let recv_two_handle = tokio::spawn(async move {
-        let mut stream = recv
-            .accept_with_cid(recv_two_cid, conn_config)
-            .await
-            .unwrap();
-        let mut buf = vec![];
-        let n = stream.read_to_eof(&mut buf).await.unwrap();
-        tracing::info!(cid.send = %recv_two_cid.send, cid.recv = %recv_two_cid.recv, "read {n} bytes from uTP stream");
-
-        assert_eq!(n, data_two_recv.len());
-        assert_eq!(buf, data_two_recv);
-    });
-
-    tokio::spawn(async move {
-        let mut stream = send
-            .connect_with_cid(send_two_cid, conn_config)
-            .await
-            .unwrap();
-        let n = stream.write(&data_two).await.unwrap();
-        assert_eq!(n, data_two.len());
-
-        let _ = stream.close().await;
-    });
-
-    let (one, two) = tokio::join!(recv_one_handle, recv_two_handle);
-    one.unwrap();
-    two.unwrap();
+    (send_handle, recv_handle)
 }
 
 // Test that a new socket has zero connections


### PR DESCRIPTION
This used to be a PR that grouped up all the changes needed to pass the high-concurrency tests. Now, with all the changes merged, the test is the only commit left, and it passes against master.

---
Previous writeup, for posterity

## Handle High Concurrency

The minimal functional changes required to pass the high-volume socket test, plus some logs, pulled from #69 

The commits should be fairly clean to inspect individually, if you're into that kind of thing.

The functional changes are:
- Bias the connection event loop, to prefer handling inbound packets. Previously, it was possible to randomly choose to timeout a connection, even if an inbound packet was waiting on the queue.
- Use exponential backoff when sending SYN times out (the test tried a *bunch* of SYNs at once, exponential backoff helps recover from this stressed condition)
- A bit more wiggle room in the default config (longer idle timeout, more connection retries, more DATA packet retries)
- Bias the socket event loop, to prefer handling socket reads (usually UDP). UDP packet drops were happening a lot on high-volume tests. It is much more work to recover from drops, than from delays to outbound sending (a side effect of preferring reads), and uTP already nicely handles delays.
- Finally, add a limit to the number of connections. This is applied on new outbound connections, but considers the total connection count.

Altogether, these changes reliably cause the new test to pass, even when bumped up to 10,000 simultaneously-launched transfers. (Though the simultaneous bit is mostly a red-herring now, since the stream prevents them from actually starting to run at the same time)

There was a probabilistic success improvement for most of these changes, though the connection limiting was the final piece that gave apparent reliability. It might be tempting to drop some of these changes and just stick to the connection limit. However, since the connection limit is a configurable value, we want to support high connection rates as much as possible. So it seems worth keeping the earlier functional changes, to do a better job if users try high values.

Notably *not* present is the "stress tracking" or "busy/idle tracking" from the socket. Both provided interesting information, but were not reliable enough to use to apply back-pressure. The added code complexity wasn't worth the (admittedly quite valuable) logs, IMO.

The logging changes are mostly not visible except in stress/failure situations, but they are very helpful for debugging, so I think we should keep them.