### PR TITLE
Remove the cap for peer_ts_diff

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -692,16 +692,11 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
         let now_micros = crate::time::now_micros();
         self.peer_recv_window = packet.window_size();
 
-        // Cap the diff. If the clock on the remote machine is behind the clock on the local
-        // machine, then we could end up with large (inaccurate) diffs. Use the max idle timeout as
-        // an upper bound on the possible diff. If the diff exceeds the bound, then assume the
-        // remote clock is behind the local clock and use a diff of 1s.
-        let peer_ts_diff = crate::time::duration_between(packet.ts_micros(), now_micros);
-        if peer_ts_diff > self.config.max_idle_timeout {
-            self.peer_ts_diff = Duration::from_secs(1);
+        self.peer_ts_diff = if packet.ts_micros() == 0 {
+            Duration::from_micros(0)
         } else {
-            self.peer_ts_diff = peer_ts_diff;
-        }
+            Duration::from_micros(now_micros.wrapping_sub(packet.ts_micros()).into())
+        };
 
         match packet.packet_type() {
             PacketType::Syn => self.on_syn(packet.seq_num()),


### PR DESCRIPTION
This changes ``ethereum/utp`` to handle this case the same way ``fluffy/utp`` and ``bittorrent/libutp`` handle it.

#### The issue we faced before

Having a cap defeats the purpose of why we get this difference. The number it gives isn't inheriently valuable since system clocks or how implementations get the time won't be the same between systems/implementations. What this measurement is useful for is the relative time delays between each client. So if this number is high or low it doesn't matter. It just matters what the delay changes are relative to each other over multiple sent packets. Using this information is how ledbat works (uTP's congestion protocol) to yeild to TCP traffic. 

Capping ``timestamp_difference_microseconds`` to 1 second defeats the purpose of this since then the other client thinks the delay on our side is constant which isn't what we want.