### PR TITLE
Limit connection count

### DIFF
--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -16,10 +16,11 @@ async fn socket() {
 
     let recv_addr = SocketAddr::from(([127, 0, 0, 1], 3400));
     let send_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
+    let max_outbound_connections = 20;
 
-    let recv = UtpSocket::bind(recv_addr).await.unwrap();
+    let recv = UtpSocket::bind(recv_addr, max_outbound_connections).await.unwrap();
     let recv = Arc::new(recv);
-    let send = UtpSocket::bind(send_addr).await.unwrap();
+    let send = UtpSocket::bind(send_addr, max_outbound_connections).await.unwrap();
     let send = Arc::new(send);
     let mut handles = vec![];
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -16,7 +16,7 @@ async fn socket() {
 
     let recv_addr = SocketAddr::from(([127, 0, 0, 1], 3400));
     let send_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
-    let max_outbound_connections = 20;
+    let max_outbound_connections = 200;
 
     let recv = UtpSocket::bind(recv_addr, max_outbound_connections).await.unwrap();
     let recv = Arc::new(recv);

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1,103 +1,84 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+
 use utp_rs::cid;
 use utp_rs::conn::ConnectionConfig;
 use utp_rs::socket::UtpSocket;
 
-#[tokio::test(flavor = "multi_thread")]
+const TEST_DATA: &[u8] = &[0xf0; 1_000_000];
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 16)]
 async fn socket() {
     tracing_subscriber::fmt::init();
 
-    let conn_config = ConnectionConfig::default();
-
-    let data_one = vec![0xef; 8192 * 2 * 2];
-    let data_one_recv = data_one.clone();
-
     let recv_addr = SocketAddr::from(([127, 0, 0, 1], 3400));
+    let send_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
+
     let recv = UtpSocket::bind(recv_addr).await.unwrap();
     let recv = Arc::new(recv);
-
-    let send_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
     let send = UtpSocket::bind(send_addr).await.unwrap();
     let send = Arc::new(send);
+    let mut handles = vec![];
 
-    let recv_one_cid = cid::ConnectionId {
-        send: 100,
-        recv: 101,
+    let start = Instant::now();
+    let num_transfers = 1500;
+    for i in 0..num_transfers {
+        // step up cid by two to avoid collisions
+        let handle = initiate_transfer(i * 2, recv_addr, recv.clone(), send_addr, send.clone()).await;
+        handles.push(handle.0);
+        handles.push(handle.1);
+    }
+
+    let result = futures::future::join_all(handles).await;
+    for res in result {
+        res.unwrap();
+    }
+    let elapsed = Instant::now() - start;
+    let megabits_sent = num_transfers as f64 * TEST_DATA.len() as f64 * 8.0 / 1_000_000.0;
+    let transfer_rate = megabits_sent / elapsed.as_secs_f64();
+    tracing::info!("finished real udp load test of {} simultaneous transfers, in {:?}, at a rate of {:.0} Mbps", num_transfers, elapsed, transfer_rate);
+}
+
+async fn initiate_transfer(
+    i: u16,
+    recv_addr: SocketAddr,
+    recv: Arc<UtpSocket<SocketAddr>>,
+    send_addr: SocketAddr,
+    send: Arc<UtpSocket<SocketAddr>>,
+) -> (JoinHandle<()>, JoinHandle<()>) {
+    let conn_config = ConnectionConfig::default();
+    let initiator_cid = 100 + i;
+    let responder_cid = 100 + i + 1;
+    let recv_cid = cid::ConnectionId {
+        send: initiator_cid,
+        recv: responder_cid,
         peer: send_addr,
     };
-    let send_one_cid = cid::ConnectionId {
-        send: 101,
-        recv: 100,
+    let send_cid = cid::ConnectionId {
+        send: responder_cid,
+        recv: initiator_cid,
         peer: recv_addr,
     };
 
-    let recv_arc = Arc::clone(&recv);
-    let recv_one_handle = tokio::spawn(async move {
-        let mut stream = recv_arc
-            .accept_with_cid(recv_one_cid, conn_config)
-            .await
-            .unwrap();
+    let recv_handle = tokio::spawn(async move {
+        let mut stream = recv.accept_with_cid(recv_cid, conn_config).await.unwrap();
         let mut buf = vec![];
         let n = stream.read_to_eof(&mut buf).await.unwrap();
-        tracing::info!(cid.send = %recv_one_cid.send, cid.recv = %recv_one_cid.recv, "read {n} bytes from uTP stream");
+        tracing::info!(cid.send = %recv_cid.send, cid.recv = %recv_cid.recv, "read {n} bytes from uTP stream");
 
-        assert_eq!(n, data_one_recv.len());
-        assert_eq!(buf, data_one_recv);
+        assert_eq!(n, TEST_DATA.len());
+        assert_eq!(buf, TEST_DATA);
     });
 
-    let send_arc = Arc::clone(&send);
-    tokio::spawn(async move {
-        let mut stream = send_arc
-            .connect_with_cid(send_one_cid, conn_config)
-            .await
-            .unwrap();
-        let n = stream.write(&data_one).await.unwrap();
-        assert_eq!(n, data_one.len());
+    let send_handle = tokio::spawn(async move {
+        let mut stream = send.connect_with_cid(send_cid, conn_config).await.unwrap();
+        let n = stream.write(TEST_DATA).await.unwrap();
+        assert_eq!(n, TEST_DATA.len());
 
-        let _ = stream.shutdown();
+        stream.shutdown().unwrap();
     });
-
-    let data_two = vec![0xfe; 8192 * 2 * 2];
-    let data_two_recv = data_two.clone();
-
-    let recv_two_cid = cid::ConnectionId {
-        send: 200,
-        recv: 201,
-        peer: send_addr,
-    };
-    let send_two_cid = cid::ConnectionId {
-        send: 201,
-        recv: 200,
-        peer: recv_addr,
-    };
-
-    let recv_two_handle = tokio::spawn(async move {
-        let mut stream = recv
-            .accept_with_cid(recv_two_cid, conn_config)
-            .await
-            .unwrap();
-        let mut buf = vec![];
-        let n = stream.read_to_eof(&mut buf).await.unwrap();
-        tracing::info!(cid.send = %recv_two_cid.send, cid.recv = %recv_two_cid.recv, "read {n} bytes from uTP stream");
-
-        assert_eq!(n, data_two_recv.len());
-        assert_eq!(buf, data_two_recv);
-    });
-
-    tokio::spawn(async move {
-        let mut stream = send
-            .connect_with_cid(send_two_cid, conn_config)
-            .await
-            .unwrap();
-        let n = stream.write(&data_two).await.unwrap();
-        assert_eq!(n, data_two.len());
-
-        let _ = stream.shutdown();
-    });
-
-    let (one, two) = tokio::join!(recv_one_handle, recv_two_handle);
-    one.unwrap();
-    two.unwrap();
+    (send_handle, recv_handle)
 }


### PR DESCRIPTION
Add the high-concurrency test & limit connection count. Because this has the test, it should probably be the last to be merged, of the sibling PRs spawned from #81 . _Edit: because it should be the last to get merged, I should probably just close this and rebase #81 when all the others are merged. I'll leave it open for now, until the TODO's are resolved_

TODO:

- [ ] Create a SocketConfig #38 
- [ ] Use SocketConfig for max connections
- [ ] ~Limit inbound connections too?~ Make config & docs clear that it is only blocking outbound connections. See https://github.com/ethereum/utp/pull/81#discussion_r1240143512
- [x] #94 