### PR TITLE
Prefer close() to shutdown(), it waits for finish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ tracing = { version = "0.1.37", features = ["std", "attributes", "log"] }
 [dev-dependencies]
 quickcheck = "1.0.3"
 tracing-subscriber = "0.3.16"
+tokio = { version = "1.25.0", features = ["test-util"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,6 @@ pub mod sent;
 pub mod seq;
 pub mod socket;
 pub mod stream;
+pub mod testutils;
 pub mod time;
 pub mod udp;

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,0 +1,130 @@
+use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use crate::cid::{ConnectionId, ConnectionPeer};
+use crate::udp::AsyncUdpSocket;
+
+/// A mock socket that can be used to simulate a perfect link.
+#[derive(Debug)]
+pub struct MockUdpSocket {
+    outbound: mpsc::UnboundedSender<Vec<u8>>,
+    inbound: mpsc::UnboundedReceiver<Vec<u8>>,
+    /// Peers identified by a letter
+    pub only_peer: char,
+    /// Defines whether the link is up. If not up, link will SILENTLY drop all sent packets.
+    up_status: Arc<AtomicBool>,
+}
+
+impl MockUdpSocket {
+    /// Get a network status controller for this socket.
+    /// In order to simulate a down link, store a false value into the status.
+    pub fn up_status(&mut self) -> Arc<AtomicBool> {
+        self.up_status.clone()
+    }
+
+    /// Should the link send packets?
+    fn is_up(&self) -> bool {
+        self.up_status.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl AsyncUdpSocket<char> for MockUdpSocket {
+    /// # Panics
+    ///
+    /// Panics if `target` is not equal to `self.only_peer`. This socket is built to support
+    /// exactly two peers communicating with each other, so it will panic if used with more.
+    async fn send_to(&mut self, buf: &[u8], target: &char) -> io::Result<usize> {
+        if target != &self.only_peer {
+            panic!("MockUdpSocket only supports sending to one peer");
+        }
+        if !self.is_up() {
+            return Ok(buf.len());
+        }
+        if let Err(err) = self.outbound.send(buf.to_vec()) {
+            Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!("channel closed: {err}"),
+            ))
+        } else {
+            Ok(buf.len())
+        }
+    }
+
+    /// # Panics
+    ///
+    /// Panics if `buf` is smaller than the packet size.
+    async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, char)> {
+        let packet = self
+            .inbound
+            .recv()
+            .await
+            .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "channel closed"))?;
+        if buf.len() < packet.len() {
+            panic!("buffer too small for perfect link");
+        }
+        let packet_len = packet.len();
+        buf[..packet_len].copy_from_slice(&packet[..]);
+        Ok((packet_len, self.only_peer))
+    }
+}
+
+impl ConnectionPeer for char {}
+
+fn build_link_pair() -> (MockUdpSocket, MockUdpSocket) {
+    let (peer_a, peer_b): (char, char) = ('A', 'B');
+    let (a_tx, a_rx) = mpsc::unbounded_channel();
+    let (b_tx, b_rx) = mpsc::unbounded_channel();
+    let a = MockUdpSocket {
+        outbound: a_tx,
+        inbound: b_rx,
+        only_peer: peer_b,
+        up_status: Arc::new(AtomicBool::new(true)),
+    };
+    let b = MockUdpSocket {
+        outbound: b_tx,
+        inbound: a_rx,
+        only_peer: peer_a,
+        up_status: Arc::new(AtomicBool::new(true)),
+    };
+    (a, b)
+}
+
+fn build_connection_id_pair(
+    socket_a: &MockUdpSocket,
+    socket_b: &MockUdpSocket,
+) -> (ConnectionId<char>, ConnectionId<char>) {
+    build_connection_id_pair_starting_at(socket_a, socket_b, 100)
+}
+
+fn build_connection_id_pair_starting_at(
+    socket_a: &MockUdpSocket,
+    socket_b: &MockUdpSocket,
+    lower_id: u16,
+) -> (ConnectionId<char>, ConnectionId<char>) {
+    let higher_id = lower_id.wrapping_add(1);
+    let a_cid = ConnectionId {
+        send: higher_id,
+        recv: lower_id,
+        peer: socket_a.only_peer,
+    };
+    let b_cid = ConnectionId {
+        send: lower_id,
+        recv: higher_id,
+        peer: socket_b.only_peer,
+    };
+    (a_cid, b_cid)
+}
+
+pub fn build_connected_pair() -> (
+    (MockUdpSocket, ConnectionId<char>),
+    (MockUdpSocket, ConnectionId<char>),
+) {
+    let (socket_a, socket_b) = build_link_pair();
+    let (a_cid, b_cid) = build_connection_id_pair(&socket_a, &socket_b);
+    ((socket_a, a_cid), (socket_b, b_cid))
+}

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -56,7 +56,7 @@ async fn socket() {
         let n = stream.write(&data_one).await.unwrap();
         assert_eq!(n, data_one.len());
 
-        let _ = stream.shutdown();
+        let _ = stream.close().await;
     });
 
     let data_two = vec![0xfe; 8192 * 2 * 2];
@@ -94,7 +94,7 @@ async fn socket() {
         let n = stream.write(&data_two).await.unwrap();
         assert_eq!(n, data_two.len());
 
-        let _ = stream.shutdown();
+        let _ = stream.close().await;
     });
 
     let (one, two) = tokio::join!(recv_one_handle, recv_two_handle);

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,47 +1,42 @@
-use std::net::SocketAddr;
+use std::io::ErrorKind;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 
-use utp_rs::cid;
+use tokio::time::timeout;
+
 use utp_rs::conn::ConnectionConfig;
 use utp_rs::socket::UtpSocket;
+
+use utp_rs::testutils;
 
 // Test that close() returns successful, after transfer is complete
 #[tokio::test]
 async fn close_is_successful_when_write_completes() {
     let conn_config = ConnectionConfig::default();
 
-    // TODO replace with a mock socket
-    let recv_addr = SocketAddr::from(([127, 0, 0, 1], 3406));
-    let recv = UtpSocket::bind(recv_addr).await.unwrap();
+    let ((send_link, send_cid), (recv_link, recv_cid)) = testutils::build_connected_pair();
+
+    let recv = UtpSocket::with_socket(recv_link);
     let recv = Arc::new(recv);
 
-    let send_addr = SocketAddr::from(([127, 0, 0, 1], 3407));
-    let send = UtpSocket::bind(send_addr).await.unwrap();
+    let send = UtpSocket::with_socket(send_link);
     let send = Arc::new(send);
-
-    let recv_one_cid = cid::ConnectionId {
-        send: 100,
-        recv: 101,
-        peer: send_addr,
-    };
-    let send_one_cid = cid::ConnectionId {
-        send: 101,
-        recv: 100,
-        peer: recv_addr,
-    };
 
     let recv_one = Arc::clone(&recv);
     let recv_one_handle = tokio::spawn(async move {
         recv_one
-            .accept_with_cid(recv_one_cid, conn_config)
+            .accept_with_cid(recv_cid, conn_config)
             .await
             .unwrap()
     });
 
+    // Keep a clone of the socket so that it doesn't drop when moved into the task.
+    // Dropping it causes all connections to exit.
     let send_one = Arc::clone(&send);
     let send_one_handle = tokio::spawn(async move {
         send_one
-            .connect_with_cid(send_one_cid, conn_config)
+            .connect_with_cid(send_cid, conn_config)
             .await
             .unwrap()
     });
@@ -74,13 +69,92 @@ async fn close_is_successful_when_write_completes() {
     let mut send_stream = send_stream_handle.await.unwrap();
 
     // close stream, which will wait for write to complete, and exit without a problem
-    send_stream.close().await.unwrap();
+    // This should happen extremely quickly.
+    match timeout(Duration::from_millis(20), send_stream.close()).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => panic!("Error closing stream: {:?}", e),
+        Err(_) => panic!("Timeout closing stream"),
+    };
 
     // confirm that data is received as expected
     recv_stream_handle.await.unwrap();
 }
 
-// TODO after adding PerfectLink from stash@{1}: WIP on test-packet-drops: 7408259 Allow for mutable state in Socket send/recv
-// Test that close() returns a timeout, if recipient is not ACKing
-// AFter adding some mechanism that sends a RESET packet, add the following test:
-// Test that close() returns ConnectionReset if recipient resets during transfer
+// Test that close() returns a timeout, if recipient is not ACKing (after a successful connection)
+#[tokio::test(start_paused = true)]
+async fn close_errors_if_all_packets_dropped() {
+    let conn_config = ConnectionConfig::default();
+
+    let ((mut send_link, send_cid), (recv_link, recv_cid)) = testutils::build_connected_pair();
+    let tx_link_up = send_link.up_status();
+
+    let recv = UtpSocket::with_socket(recv_link);
+    let recv = Arc::new(recv);
+
+    let send = UtpSocket::with_socket(send_link);
+    let send = Arc::new(send);
+
+    let recv_one = Arc::clone(&recv);
+    let recv_one_handle = tokio::spawn(async move {
+        recv_one
+            .accept_with_cid(recv_cid, conn_config)
+            .await
+            .unwrap()
+    });
+
+    // Keep a clone of the socket so that it doesn't drop when moved into the task.
+    // Dropping it causes all connections to exit.
+    let send_one = Arc::clone(&send);
+    let send_one_handle = tokio::spawn(async move {
+        send_one
+            .connect_with_cid(send_cid, conn_config)
+            .await
+            .unwrap()
+    });
+
+    let (tx_one, rx_one) = tokio::join!(send_one_handle, recv_one_handle,);
+    let mut send_stream = tx_one.unwrap();
+    let mut recv_stream = rx_one.unwrap();
+
+    // ******* DISABLE NETWORK LINK ********
+    tx_link_up.store(false, Ordering::SeqCst);
+
+    // data to send
+    const DATA_LEN: usize = 100;
+    let data = [0xa5; DATA_LEN];
+
+    // send data
+    let send_stream_handle = tokio::spawn(async move {
+        match send_stream.write(&data).await {
+            Ok(written_len) => assert_eq!(written_len, DATA_LEN),
+            Err(e) => panic!("Error sending data: {:?}", e),
+        };
+        send_stream
+    });
+
+    // recv data
+    let recv_stream_handle = tokio::spawn(async move {
+        let mut read_buf = vec![];
+        let read_err = recv_stream.read_to_eof(&mut read_buf).await.unwrap_err();
+        assert_eq!(read_err.kind(), ErrorKind::TimedOut);
+    });
+
+    // Wait for send to start
+    let mut send_stream = send_stream_handle.await.unwrap();
+
+    // Close stream, which will fail because network is disabled.
+    match timeout(Duration::from_secs(20), send_stream.close()).await {
+        Ok(Ok(_)) => panic!("Stream closed successfully, but should have timed out"),
+        Ok(Err(e)) => {
+            // The stream must time out when waiting to close, if the network is disabled.
+            assert_eq!(e.kind(), ErrorKind::TimedOut);
+        }
+        Err(e) => panic!(
+            "The stream did not timeout on close() fast enough, giving up after: {:?}",
+            e
+        ),
+    };
+
+    // Wait to confirm that the read will time out, also.
+    recv_stream_handle.await.unwrap();
+}

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,0 +1,86 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use utp_rs::cid;
+use utp_rs::conn::ConnectionConfig;
+use utp_rs::socket::UtpSocket;
+
+// Test that close() returns successful, after transfer is complete
+#[tokio::test]
+async fn close_is_successful_when_write_completes() {
+    let conn_config = ConnectionConfig::default();
+
+    // TODO replace with a mock socket
+    let recv_addr = SocketAddr::from(([127, 0, 0, 1], 3406));
+    let recv = UtpSocket::bind(recv_addr).await.unwrap();
+    let recv = Arc::new(recv);
+
+    let send_addr = SocketAddr::from(([127, 0, 0, 1], 3407));
+    let send = UtpSocket::bind(send_addr).await.unwrap();
+    let send = Arc::new(send);
+
+    let recv_one_cid = cid::ConnectionId {
+        send: 100,
+        recv: 101,
+        peer: send_addr,
+    };
+    let send_one_cid = cid::ConnectionId {
+        send: 101,
+        recv: 100,
+        peer: recv_addr,
+    };
+
+    let recv_one = Arc::clone(&recv);
+    let recv_one_handle = tokio::spawn(async move {
+        recv_one
+            .accept_with_cid(recv_one_cid, conn_config)
+            .await
+            .unwrap()
+    });
+
+    let send_one = Arc::clone(&send);
+    let send_one_handle = tokio::spawn(async move {
+        send_one
+            .connect_with_cid(send_one_cid, conn_config)
+            .await
+            .unwrap()
+    });
+
+    let (tx_one, rx_one) = tokio::join!(send_one_handle, recv_one_handle,);
+    let mut send_stream = tx_one.unwrap();
+    let mut recv_stream = rx_one.unwrap();
+
+    // data to send
+    const DATA_LEN: usize = 100;
+    let data = [0xa5; DATA_LEN];
+
+    // send data
+    let send_stream_handle = tokio::spawn(async move {
+        match send_stream.write(&data).await {
+            Ok(written_len) => assert_eq!(written_len, DATA_LEN),
+            Err(e) => panic!("Error sending data: {:?}", e),
+        };
+        send_stream
+    });
+
+    // recv data
+    let recv_stream_handle = tokio::spawn(async move {
+        let mut read_buf = vec![];
+        let _ = recv_stream.read_to_eof(&mut read_buf).await.unwrap();
+        assert_eq!(read_buf, data.to_vec());
+    });
+
+    // wait for send to start
+    let mut send_stream = send_stream_handle.await.unwrap();
+
+    // close stream, which will wait for write to complete, and exit without a problem
+    send_stream.close().await.unwrap();
+
+    // confirm that data is received as expected
+    recv_stream_handle.await.unwrap();
+}
+
+// TODO after adding PerfectLink from stash@{1}: WIP on test-packet-drops: 7408259 Allow for mutable state in Socket send/recv
+// Test that close() returns a timeout, if recipient is not ACKing
+// AFter adding some mechanism that sends a RESET packet, add the following test:
+// Test that close() returns ConnectionReset if recipient resets during transfer


### PR DESCRIPTION
Fix #89 

stream.close().await will not return until the connection exits, either from an error, or from all data being written and ACKed.

To simplify, `shutdown()` is no longer part of the public API.