### PR TITLE
make default conn config more robust to packet drops

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -128,16 +128,17 @@ pub struct ConnectionConfig {
     pub target_delay: Duration,
 }
 
+pub const DEFAULT_MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
 impl Default for ConnectionConfig {
     fn default() -> Self {
-        let max_idle_timeout = Duration::from_secs(10);
         Self {
-            max_conn_attempts: 3,
-            max_idle_timeout,
+            max_conn_attempts: 5,
+            max_idle_timeout: DEFAULT_MAX_IDLE_TIMEOUT,
             max_packet_size: congestion::DEFAULT_MAX_PACKET_SIZE_BYTES as u16,
             initial_timeout: congestion::DEFAULT_INITIAL_TIMEOUT,
             min_timeout: congestion::DEFAULT_MIN_TIMEOUT,
-            max_timeout: max_idle_timeout,
+            max_timeout: DEFAULT_MAX_IDLE_TIMEOUT / 4,
             target_delay: Duration::from_micros(congestion::DEFAULT_TARGET_MICROS.into()),
         }
     }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -112,7 +112,7 @@ async fn test_empty_socket_conn_count() {
 
 // Test that a socket returns 2 from num_connections after connecting twice
 #[tokio::test]
-async fn test_socket_reports_one_connection() {
+async fn test_socket_reports_two_connections() {
     let conn_config = ConnectionConfig::default();
 
     let recv_addr = SocketAddr::from(([127, 0, 0, 1], 3404));

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -5,13 +5,13 @@ use std::time::Duration;
 
 use tokio::time::timeout;
 
-use utp_rs::conn::ConnectionConfig;
+use utp_rs::conn::{ConnectionConfig, DEFAULT_MAX_IDLE_TIMEOUT};
 use utp_rs::socket::UtpSocket;
 
 use utp_rs::testutils;
 
 // How long should tests expect the connection to wait before timing out due to inactivity?
-const EXPECTED_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
+const EXPECTED_IDLE_TIMEOUT: Duration = DEFAULT_MAX_IDLE_TIMEOUT;
 
 // Test that close() returns successful, after transfer is complete
 #[tokio::test]


### PR DESCRIPTION
Longer idle timeout has obvious effect of reducing connection failures due to idle timeout. This idle timeout doesn't seem to be specified anywhere in the main utp spec, we are just doing it. 10s seemed reasonable, but when trying to recover from a couple dropped packets, it gets less reasonable.

The retry timeout should be small enough that if it maxes out, there are a few chances at reattempts before the idle timeout. Setting it to /4 of the idle timeout means we should get at least 3 attempts (the 4th will race with the idle).

In high packet-drop scenarios, like 10%, then only making 3 attempts has a 1/1000 chance of failing the connection attempt. With 1000 transfers, the expected value of connection failures is about 1 per test.  By increasing to 5 attempts, the connection failures effectively disappeared.

Assuming independent probabilities of packet drops (haha), that means the packet drop rate can go up to 25% before failing about 1 out of 1000 connection attempts.

---

I also tossed in a bonus fix: to make the name of a test match its comments & content.