### PR TITLE
Fix ConnectionId hashmap key bug

### DIFF
--- a/src/cid.rs
+++ b/src/cid.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::fmt::Debug;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 
 /// A remote peer.
@@ -8,12 +8,27 @@ pub trait ConnectionPeer: Clone + Debug + Eq + Hash + PartialEq + Send + Sync {}
 
 impl ConnectionPeer for SocketAddr {}
 
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug)]
 pub struct ConnectionId<P> {
     pub send: u16,
     pub recv: u16,
     pub peer: P,
 }
+
+impl<P> Hash for ConnectionId<P> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.send.hash(state);
+        self.recv.hash(state);
+    }
+}
+
+impl<P> PartialEq for ConnectionId<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.send == other.send && self.recv == other.recv
+    }
+}
+
+impl<P> Eq for ConnectionId<P> {}
 
 pub trait ConnectionIdGenerator<P> {
     fn cid(&mut self, peer: P, is_initiator: bool) -> ConnectionId<P>;


### PR DESCRIPTION
fixes https://github.com/ethereum/trin/issues/927

## Bug Report info
In Galdos there were audits where content would be found but the uTP transfer would fail with the error ``Unable to establish uTP conn based on Content response err=timed out``

Here is a log of the bug 
```nim
2023-09-18T23:19:13.648255Z DEBUG uTP{send=737 recv=736}: utp_rs::conn: uTP conn starting...
2023-09-18T23:19:13.807470Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30115 ack=27342
2023-09-18T23:19:13.807533Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=State seq=30113 ack=27342
2023-09-18T23:19:13.807587Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30113 ack=27342
2023-09-18T23:19:13.807641Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30114 ack=27342
2023-09-18T23:19:14.650276Z DEBUG uTP{send=737 recv=736}: utp_rs::conn: timeout seq=27342 ack=0 packet=Syn
2023-09-18T23:19:14.829741Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30115 ack=27342
2023-09-18T23:19:14.829885Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30113 ack=27342
2023-09-18T23:19:14.830015Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30114 ack=27342
2023-09-18T23:19:14.830144Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=State seq=30116 ack=27342
2023-09-18T23:19:16.812812Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30115 ack=27342
2023-09-18T23:19:16.812959Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30113 ack=27342
2023-09-18T23:19:16.813092Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30114 ack=27342
2023-09-18T23:19:16.902186Z DEBUG uTP{send=737 recv=736}: utp_rs::conn: timeout seq=27342 ack=0 packet=Syn
2023-09-18T23:19:16.902285Z DEBUG uTP{send=737 recv=736}: utp_rs::conn: log_msg="retrying connection, after 2 attempts"
2023-09-18T23:19:17.067765Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=State seq=30116 ack=27342
2023-09-18T23:19:20.278782Z DEBUG uTP{send=737 recv=736}: utp_rs::conn: timeout seq=27342 ack=0 packet=Syn
2023-09-18T23:19:20.278877Z  INFO uTP{send=737 recv=736}: utp_rs::conn: log_msg="retrying connection, after 3 attempts"
2023-09-18T23:19:20.486978Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=State seq=30116 ack=27342
2023-09-18T23:19:20.814225Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30113 ack=27342
2023-09-18T23:19:20.814316Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30114 ack=27342
2023-09-18T23:19:20.815389Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30115 ack=27342
2023-09-18T23:19:25.343070Z DEBUG uTP{send=737 recv=736}: utp_rs::conn: timeout seq=27342 ack=0 packet=Syn
2023-09-18T23:19:25.343150Z  WARN uTP{send=737 recv=736}: utp_rs::conn: log_msg="retrying connection, after 4 attempts"
2023-09-18T23:19:25.502318Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=State seq=30116 ack=27342
2023-09-18T23:19:28.813793Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30113 ack=27342
2023-09-18T23:19:28.814911Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30115 ack=27342
2023-09-18T23:19:28.815068Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30114 ack=27342
2023-09-18T23:19:32.938851Z DEBUG uTP{send=737 recv=736}: utp_rs::conn: timeout seq=27342 ack=0 packet=Syn
2023-09-18T23:19:32.938961Z  WARN uTP{send=737 recv=736}: utp_rs::conn: log_msg="retrying connection, after 5 attempts"
2023-09-18T23:19:33.140097Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=State seq=30116 ack=27342
2023-09-18T23:19:43.817537Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30114 ack=27342
2023-09-18T23:19:43.817743Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30113 ack=27342
2023-09-18T23:19:43.817904Z DEBUG utp_rs::socket: received uTP packet for non-existing conn cid=736 packet=Data seq=30115 ack=27342
2023-09-18T23:19:44.331636Z DEBUG uTP{send=737 recv=736}: utp_rs::conn: timeout seq=27342 ack=0 packet=Syn
2023-09-18T23:19:44.331739Z ERROR uTP{send=737 recv=736}: utp_rs::conn: quitting connection attempt, after 6 tries
2023-09-18T23:19:44.331809Z DEBUG uTP{send=737 recv=736}: utp_rs::conn: uTP conn closing... err=Some(TimedOut)
2023-09-18T23:19:44.332080Z DEBUG utp_rs::socket: uTP conn shutdown cid.send=737 cid.recv=736
2023-09-18T23:19:44.332283Z  WARN portalnet::overlay_service: Unable to establish uTP conn based on Content response err=timed out cid.send=737 cid.recv=736 peer=Some("t 0.1.1-alpha.1-9f5123")
```

## The issue Found
After debugging I found the issue was
```nim
init_cid=
ConnectionId { send: 12358, recv: 12357, peer: UtpEnr(Enr { id: Some("v4"), seq: 1, NodeId: 0xd6f4b39b42db604b9f97c4ce8af8500993a932c31ca8184161fa5799f75c0eae, signature: "ddd7be35546b7871840c40856d5376cea7585bf4aebcaa21a07d28d4ec4a7b4b72c8e3a131c2648f733326d9c36feae3ad62faf28c96ce788efb6e48912f08a1", IpV4 UDP Socket: Some(128.199.99.16:9000), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d323865363037"), ("secp256k1", "a102d918bf6ee4b547c602b2188f6fab41ceb0257ace736dcdf2cc477218f2050508")] }) }

ConnectionId { send: 12358, recv: 12357, peer: UtpEnr(Enr { id: Some("v4"), seq: 1, NodeId: 0xd6f4b39b42db604b9f97c4ce8af8500993a932c31ca8184161fa5799f75c0eae, signature: "530867289b0c1bd403304ab99c3d2337ffeb6af2a8b3a1e01efb1c16c46ac4745f6b1e8a63ec207d58abd8335dc25418ab2d77c338330e459e1d2f246192af4c", IpV4 UDP Socket: Some(128.199.99.16:9000), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d376162383239"), ("secp256k1", "a102d918bf6ee4b547c602b2188f6fab41ceb0257ace736dcdf2cc477218f2050508")] }) }
```
The top being the key we are trying to check and the bottom being the connectID in the hashtable ``conn``
![image](https://github.com/ethereum/utp/assets/31669092/4a4a64e9-0a5e-424a-9a02-9844918d3c0b)


The issue was ``peer`` an attribute in ``ConnectionID`` would change when Trin got different Enr's for the same uTP Steam causing the HashMap's get statements to fail since the ``updated enr != old enr``

## Solution:
Implement Hash, Eq, PartialEq ourselves excluding the ``peer`` parameter which isn't stable as found above.