### PR TITLE
chore: add peer info to debug starting log

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -221,7 +221,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
         mut reads: mpsc::UnboundedReceiver<Read>,
         mut shutdown: oneshot::Receiver<()>,
     ) -> io::Result<()> {
-        tracing::debug!("uTP conn starting...");
+        tracing::debug!("uTP conn starting... {:?}", self.cid.peer);
 
         // If we are the initiating endpoint, then send the SYN. If we are the accepting endpoint,
         // then send the SYN-ACK.

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -27,7 +27,7 @@ async fn socket() {
     let mut handles = FuturesUnordered::new();
 
     let start = Instant::now();
-    let num_transfers = 2000;
+    let num_transfers = 1000;
     for i in 0..num_transfers {
         // step up cid by two to avoid collisions
         let handle =


### PR DESCRIPTION
A lot of the time I am debugging unless a connection fails there are no logs on information about the peer. This makes things hard because without this information I have no clue which uTP implementation I am looking at.