### PR TITLE
chore: switch to one way acks

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -364,7 +364,8 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                 recv_buf,
             } => {
                 let mut local_fin = None;
-                if self.pending_writes.is_empty() && send_buf.is_empty() {
+                if self.pending_writes.is_empty() && send_buf.is_empty() && self.unacked.is_empty()
+                {
                     // TODO: Helper for construction of FIN.
                     let recv_window = recv_buf.available() as u32;
                     let seq_num = sent_packets.next_seq_num();
@@ -412,7 +413,11 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                 // If we have not sent our FIN, and there are no pending writes, and there is no
                 // pending data in the send buffer, then send our FIN. If there were still data to
                 // send, then we would not know which sequence number to assign to our FIN.
-                if local_fin.is_none() && self.pending_writes.is_empty() && send_buf.is_empty() {
+                if local_fin.is_none()
+                    && self.pending_writes.is_empty()
+                    && send_buf.is_empty()
+                    && self.unacked.is_empty()
+                {
                     // TODO: Helper for construction of FIN.
                     let recv_window = recv_buf.available() as u32;
                     let seq_num = sent_packets.next_seq_num();

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -826,21 +826,6 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                 self.state = State::Closed { err: None };
             }
         }
-
-        // If both endpoints have exchanged FINs and all data has been received/acknowledged, then
-        // close the connection.
-        if let State::Closing {
-            local_fin: Some(..),
-            remote_fin: Some(remote),
-            sent_packets,
-            recv_buf,
-            ..
-        } = &mut self.state
-        {
-            if !sent_packets.has_unacked_packets() && recv_buf.ack_num() == *remote {
-                self.state = State::Closed { err: None };
-            }
-        }
     }
 
     fn process_ack(

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -314,9 +314,26 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                 }
                 () = &mut idle_timeout => {
                     if !std::matches!(self.state, State::Closed { .. }) {
+                        // Warn that we are quitting the connection, due to a lack of activity.
+
+                        // If both endpoints have exchanged FINs, and our FIN is the only
+                        // unacknowledged packet, then do not emit a warning. It's not a big deal
+                        // that their STATE for our FIN got dropped: we handled their FIN anyway.
                         let unacked: Vec<u16> = self.unacked.keys().copied().collect();
-                        tracing::warn!(?unacked, "idle timeout expired, closing...");
-                        self.state = State::Closed { err: Some(Error::TimedOut) };
+                        let finished = match self.state {
+                            State::Closing { local_fin, .. } => unacked.len() == 1 && local_fin.is_some() && &local_fin.unwrap() == unacked.last().unwrap(),
+                            _ => false,
+                        };
+
+                        let err = if finished {
+                            tracing::debug!(?self.state, ?unacked, "idle timeout expired, but only missing ACK for local FIN");
+                            None
+                        } else {
+                            tracing::warn!(?self.state, ?unacked, "closing, idle for too long...");
+                            Some(Error::TimedOut)
+                        };
+
+                        self.state = State::Closed { err };
                     }
                 }
                 _ = &mut shutdown, if !shutting_down => {

--- a/src/sent.rs
+++ b/src/sent.rs
@@ -359,7 +359,7 @@ impl SentPackets {
     ///
     /// Returns `None` if none of the (possibly zero) packets have been acknowledged.
     // TODO: Cache this value, (possibly) updating on each ACK.
-    fn last_ack_num(&self) -> Option<u16> {
+    pub fn last_ack_num(&self) -> Option<u16> {
         if self.packets.is_empty() {
             return None;
         }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -20,7 +20,9 @@ struct Accept<P> {
     config: ConnectionConfig,
 }
 
-const MAX_UDP_PAYLOAD_SIZE: usize = u16::MAX as usize;
+/// we will never recieve a UDP packet bigger then this, we don't want to allocate
+/// u16 memory in every iteration of the loop as it is only a theorical max size
+const MAX_UDP_PAYLOAD_SIZE: usize = 1500_usize;
 
 pub struct UtpSocket<P> {
     conns: Arc<RwLock<HashMap<ConnectionId<P>, ConnChannel>>>,
@@ -41,7 +43,7 @@ impl<P> UtpSocket<P>
 where
     P: ConnectionPeer + 'static,
 {
-    pub fn with_socket<S>(mut socket: S) -> Self
+    pub fn with_socket<S>(socket: S) -> Self
     where
         S: AsyncUdpSocket<P> + 'static,
     {
@@ -55,6 +57,7 @@ where
 
         let mut incoming_conns = HashMap::new();
 
+        let (socket_reader_tx, mut socket_reader_rx) = mpsc::unbounded_channel();
         let (socket_event_tx, mut socket_event_rx) = mpsc::unbounded_channel();
         let (accepts_tx, mut accepts_rx) = mpsc::unbounded_channel();
 
@@ -64,13 +67,25 @@ where
             accepts: accepts_tx,
             socket_events: socket_event_tx.clone(),
         };
+        let socket = Arc::from(socket);
+        let socket_recv = socket.clone();
 
         tokio::spawn(async move {
-            let mut buf = [0; MAX_UDP_PAYLOAD_SIZE];
+            loop {
+                let mut buf = vec![0; MAX_UDP_PAYLOAD_SIZE];
+                tokio::select! {
+                    Ok((n, src)) = socket_recv.recv_from(buf.as_mut()) => {
+                        socket_reader_tx.send((n, src, buf)).expect("Wasn't able to send on socket_reader_tx unbounded channel");
+                    }
+                }
+            }
+        });
+
+        tokio::spawn(async move {
             loop {
                 tokio::select! {
                     biased;
-                    Ok((n, src)) = socket.recv_from(&mut buf) => {
+                    Some((n, src, buf)) = socket_reader_rx.recv() => {
                         let packet = match Packet::decode(&buf[..n]) {
                             Ok(pkt) => pkt,
                             Err(..) => {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -15,7 +15,7 @@ const BUF: usize = 1024 * 1024;
 
 pub struct UtpStream<P> {
     cid: ConnectionId<P>,
-    reads: mpsc::UnboundedSender<conn::Read>,
+    reads: mpsc::UnboundedReceiver<conn::Read>,
     writes: mpsc::UnboundedSender<conn::Write>,
     shutdown: Option<oneshot::Sender<()>>,
     conn_handle: Option<task::JoinHandle<io::Result<()>>>,
@@ -33,21 +33,26 @@ where
         stream_events: mpsc::UnboundedReceiver<StreamEvent>,
         connected: oneshot::Sender<io::Result<()>>,
     ) -> Self {
-        let mut conn =
-            conn::Connection::<BUF, P>::new(cid.clone(), config, syn, connected, socket_events);
-
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let (reads_tx, reads_rx) = mpsc::unbounded_channel();
         let (writes_tx, writes_rx) = mpsc::unbounded_channel();
+        let mut conn = conn::Connection::<BUF, P>::new(
+            cid.clone(),
+            config,
+            syn,
+            connected,
+            socket_events,
+            reads_tx,
+        );
         let conn_handle = tokio::spawn(async move {
-            conn.event_loop(stream_events, writes_rx, reads_rx, shutdown_rx)
+            conn.event_loop(stream_events, writes_rx, shutdown_rx)
                 .instrument(tracing::info_span!("uTP", send = cid.send, recv = cid.recv))
                 .await
         });
 
         Self {
             cid,
-            reads: reads_tx,
+            reads: reads_rx,
             writes: writes_tx,
             shutdown: Some(shutdown_tx),
             conn_handle: Some(conn_handle),
@@ -64,16 +69,11 @@ where
 
         let mut n = 0;
         loop {
-            let (tx, rx) = oneshot::channel();
-            self.reads
-                .send((buf.capacity(), tx))
-                .map_err(|_| io::Error::from(io::ErrorKind::NotConnected))?;
-
-            match rx.await {
-                Ok(result) => match result {
+            match self.reads.recv().await {
+                Some(data) => match data {
                     Ok(mut data) => {
                         if data.is_empty() {
-                            break Ok(n);
+                            return Ok(n);
                         }
                         n += data.len();
                         buf.append(&mut data);
@@ -84,7 +84,7 @@ where
                     }
                     Err(err) => return Err(err),
                 },
-                Err(err) => return Err(io::Error::new(io::ErrorKind::Other, format!("{err:?}"))),
+                None => tracing::debug!("read buffer was sent None"),
             }
         }
     }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -11,18 +11,18 @@ use crate::cid::ConnectionPeer;
 pub trait AsyncUdpSocket<P: ConnectionPeer>: Send + Sync {
     /// Attempts to send data on the socket to a given address.
     /// Note that this should return nearly immediately, rather than awaiting something internally.
-    async fn send_to(&mut self, buf: &[u8], target: &P) -> io::Result<usize>;
+    async fn send_to(&self, buf: &[u8], target: &P) -> io::Result<usize>;
     /// Attempts to receive a single datagram on the socket.
-    async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, P)>;
+    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, P)>;
 }
 
 #[async_trait]
 impl AsyncUdpSocket<SocketAddr> for UdpSocket {
-    async fn send_to(&mut self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
+    async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
         UdpSocket::send_to(self, buf, target).await
     }
 
-    async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         UdpSocket::recv_from(self, buf).await
     }
 }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -235,11 +235,14 @@ async fn close_succeeds_if_only_fin_ack_dropped() {
     //  - Sender is missing the recipient's FIN and times out with failure
     rx_link_up.store(false, Ordering::SeqCst);
 
+    // Since switching to one-way FIN-ACK, If sender sent fin and everything is acked, but fin the
+    // the transfer is considered successful
+    // close after write() now, and close after reading should error.
     match timeout(EXPECTED_IDLE_TIMEOUT * 2, send_stream.close()).await {
-        Ok(Ok(_)) => panic!("Send stream closed successfully, but should have timed out"),
+        Ok(Ok(_)) => {}
         Ok(Err(e)) => {
             // The stream must time out when waiting to close, because recipient's FIN is missing
-            assert_eq!(e.kind(), ErrorKind::TimedOut);
+            panic!("Send stream closed successfully, shouldn't have errored out: {e}");
         }
         Err(e) => {
             panic!("The send stream did not timeout on close() fast enough, giving up after: {e:?}")
@@ -256,7 +259,7 @@ async fn close_succeeds_if_only_fin_ack_dropped() {
             // The stream will already be disconnected by the read_to_eof() call, so we expect a
             // NotConnected error here.
             assert_eq!(e.kind(), ErrorKind::NotConnected);
-        },
+        }
         Err(e) => {
             panic!("The recv stream did not timeout on close() fast enough, giving up after: {e:?}")
         }


### PR DESCRIPTION
# Why
Every other uTP implementation uses one way fins.

We on the other hand use two way fins, like TCP. This has some advantages in some cases. But every usecase of uTP has been sending data one way.

Because we use two way and fluffy uses one way we have this problem where we only try to handle one way fins on the timeout of our connection which delays us finishing the uTP connection currently on Trin this is set to 1.25 seconds, this delay might also grow in size but that symantic interaction doesn't matter and any delay is enough justification to make this change. This delay will happen whenever we interact with Fluffy or Ultralight and if we want adoption this is unacceptable.

This is also currently causing interop issues with our bridge, well we can add another timeout exception for this case, it wouldn't fix the 1.25s delay so we might as well just implement 1 way fins.

https://portal-hive.ethdevops.io/?page=v-pills-results-tab&suite=1701568288-22f1ef76b380011a7f14fa3c85205088.json
Here is an example where these tests are failing because Trin thinks the uTP transfer is timing out, fluffy thinks it is successful. And in reality fluffy got the data, and we are waiting for no reason. We also spam fluffy with 8 fin packets for no reason which is another reason to do 1 way fins.


I tested this change on portal-hive and all tests passed using it using Trin and Fluffy. I tested the trin-bridge test again between fluffy and trin and it worked so it definitly fixes the issue I was seeing. In this process I also double checked the uTP logs to make sure there wasn't anything funny.

```nim
INFO[12-02|22:09:03] hiveproxy started                        container=814974ee4b19 addr=172.17.0.2:8081
INFO[12-02|22:09:03] API: suite started                       suite=0 name=trin-bridge-tests
INFO[12-02|22:09:03] API: test started                        suite=0 test=1 name="Trin bridge tests"
INFO[12-02|22:09:03] API: test started                        suite=0 test=2 name="Bridge test. A:fluffy --> B:fluffy"
INFO[12-02|22:09:04] API: client fluffy started               suite=0 test=2 container=5907afe4
INFO[12-02|22:09:04] API: client fluffy started               suite=0 test=2 container=6567d36d
INFO[12-02|22:09:04] API: client trin-bridge started          suite=0 test=2 container=fccdaf5f
INFO[12-02|22:09:18] API: test ended                          suite=0 test=2 pass=true
INFO[12-02|22:09:18] API: test started                        suite=0 test=3 name="Bridge test. A:fluffy --> B:trin"
INFO[12-02|22:09:18] API: client fluffy started               suite=0 test=3 container=f34274b2
INFO[12-02|22:09:19] API: client trin started                 suite=0 test=3 container=169b4b63
INFO[12-02|22:09:19] API: client trin-bridge started          suite=0 test=3 container=e28e7288
INFO[12-02|22:09:33] API: test ended                          suite=0 test=3 pass=true
INFO[12-02|22:09:33] API: test started                        suite=0 test=4 name="Bridge test. A:trin --> B:fluffy"
INFO[12-02|22:09:33] API: client trin started                 suite=0 test=4 container=80aad6e7
INFO[12-02|22:09:34] API: client fluffy started               suite=0 test=4 container=420b1cbc
INFO[12-02|22:09:34] API: client trin-bridge started          suite=0 test=4 container=ac997bce
INFO[12-02|22:09:47] API: test ended                          suite=0 test=4 pass=true
INFO[12-02|22:09:47] API: test started                        suite=0 test=5 name="Bridge test. A:trin --> B:trin"
INFO[12-02|22:09:48] API: client trin started                 suite=0 test=5 container=e9f6a740
INFO[12-02|22:09:48] API: client trin started                 suite=0 test=5 container=4bd2c4c7
INFO[12-02|22:09:49] API: client trin-bridge started          suite=0 test=5 container=532f876e
INFO[12-02|22:10:02] API: test ended                          suite=0 test=5 pass=true
INFO[12-02|22:10:02] API: test ended                          suite=0 test=1 pass=true
INFO[12-02|22:10:02] API: suite ended                         suite=0
INFO[12-02|22:10:03] simulation trin-bridge finished          suites=1 tests=5 failed=0
```

Here are the results with the change, the link above shows it all failing.

# what did I do

- I removed our timeout special case exception because it is no longer needed and we don't want to support symantics like that going forward as delay = bad.
- I added 2 checks in ``on_packet()`` for the sender and receiver cases for handling one way acks 
- I had to reconfigure reads a bit because the way it was setup looked like it was copy pasted after ``write-buffer`` was written. The while pending_read.pop_front statements doesn't work, because it relied on a gridlock system so it would be impossible for it to even loop more then once. Because the loop in stream.rs only added a new one shot channel, when it was done handling the last one. So the while loops was functionally useless in ``process_reads``. I also needed to do it this way so we would be able to flush the recv-buffer before closing the connection. 
