### PR TITLE
fix: allow Connection::eof to send empty result with one instead of two calls to Connection::process_reads()

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -15,7 +15,7 @@ const BUF: usize = 1024 * 1024;
 
 pub struct UtpStream<P> {
     cid: ConnectionId<P>,
-    reads: mpsc::UnboundedSender<conn::Read>,
+    reads: mpsc::UnboundedReceiver<conn::Read>,
     writes: mpsc::UnboundedSender<conn::Write>,
     shutdown: Option<oneshot::Sender<()>>,
     conn_handle: Option<task::JoinHandle<io::Result<()>>>,
@@ -33,21 +33,26 @@ where
         stream_events: mpsc::UnboundedReceiver<StreamEvent>,
         connected: oneshot::Sender<io::Result<()>>,
     ) -> Self {
-        let mut conn =
-            conn::Connection::<BUF, P>::new(cid.clone(), config, syn, connected, socket_events);
-
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let (reads_tx, reads_rx) = mpsc::unbounded_channel();
         let (writes_tx, writes_rx) = mpsc::unbounded_channel();
+        let mut conn = conn::Connection::<BUF, P>::new(
+            cid.clone(),
+            config,
+            syn,
+            connected,
+            socket_events,
+            reads_tx,
+        );
         let conn_handle = tokio::spawn(async move {
-            conn.event_loop(stream_events, writes_rx, reads_rx, shutdown_rx)
+            conn.event_loop(stream_events, writes_rx, shutdown_rx)
                 .instrument(tracing::info_span!("uTP", send = cid.send, recv = cid.recv))
                 .await
         });
 
         Self {
             cid,
-            reads: reads_tx,
+            reads: reads_rx,
             writes: writes_tx,
             shutdown: Some(shutdown_tx),
             conn_handle: Some(conn_handle),
@@ -64,16 +69,11 @@ where
 
         let mut n = 0;
         loop {
-            let (tx, rx) = oneshot::channel();
-            self.reads
-                .send((buf.capacity(), tx))
-                .map_err(|_| io::Error::from(io::ErrorKind::NotConnected))?;
-
-            match rx.await {
-                Ok(result) => match result {
+            match self.reads.recv().await {
+                Some(data) => match data {
                     Ok(mut data) => {
                         if data.is_empty() {
-                            break Ok(n);
+                            return Ok(n);
                         }
                         n += data.len();
                         buf.append(&mut data);
@@ -84,7 +84,7 @@ where
                     }
                     Err(err) => return Err(err),
                 },
-                Err(err) => return Err(io::Error::new(io::ErrorKind::Other, format!("{err:?}"))),
+                None => tracing::debug!("read buffer was sent None"),
             }
         }
     }


### PR DESCRIPTION
## what are the current problems 
https://github.com/ethereum/utp/blob/83d256faafa493b500f4378883bc18f5010a142d/src/conn.rs#L590-L625
- Because of how ``pending_reads`` works it can only ever contain one read channel to send data back with. This seems like a mistake, because if the code was intentionally written with only one read per ``loop { select!() }`` in a lockstep pattern, why would this code be written using ``while let`` instead of ``if let``.
- This pattern also causes another problem if the ``recv_buf`` uses the only ``pending_reads`` channel avaliable per ``process_reads()`` call. ``if self.eof() {`` can't send back it's result, which is unidle as then it has to wait to the for the next call of ``process_reads()`` to happen assuming ``pending_reads`` is refilled with another channel which is unidle as ``read_to_eof`` could have just been returned in the last call of ``process_reads()`` if this lockstep pattern wasn't in place.

So with this PR ``read_to_eof()`` will return the data after one call instead of two calls of ``Connection::process_reads()`` assuming ``self.eof()`` returns true of course.

stream.rs
```nim
    pub async fn read_to_eof(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
        // Reserve space in the buffer to avoid expensive allocation for small reads.
        buf.reserve(2048);

        let mut n = 0;
        loop {
            let (tx, rx) = oneshot::channel();
            self.reads
                .send((buf.capacity(), tx))
                .map_err(|_| io::Error::from(io::ErrorKind::NotConnected))?;

            match rx.await {
```

conn.rs
```nim
    fn on_read(&mut self, read: Read) {
        let (len, tx) = read;
        match &mut self.state {
            State::Connecting(..) | State::Established { .. } | State::Closing { .. } => {
                self.pending_reads.push_back((len, tx))
            }
            State::Closed { err } => {
                let result = match err {
                    Some(err) => Err(io::Error::from(io::ErrorKind::from(*err))),
                    None => Ok(vec![]),
                };
                let _ = tx.send(result);
            }
        }

        self.process_reads();

        self.readable.notify_waiters();
    }
```
Here is the ``read_to_eof()`` the loop generates a channel then awaits it so only one can be processed per by ``process_reads()`` after ``on_read()`` puts the channel in ``pending_reads`` deque.

This is what I meant it was stuck in a lockstep pattern to send data back.