### PR TITLE
fix: if everything but our fin was acked success there fin doesn't matter

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -325,7 +325,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
 
                         let unacked: Vec<u16> = self.unacked.keys().copied().collect();
                         let finished = match self.state {
-                            State::Closing { local_fin, remote_fin, .. } => unacked.len() == 1 && local_fin.is_some() && &local_fin.unwrap() == unacked.last().unwrap() && remote_fin.is_some(),
+                            State::Closing { local_fin, .. } => unacked.len() == 1 && local_fin.is_some() && &local_fin.unwrap() == unacked.last().unwrap(),
                             _ => false,
                         };
 

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -235,11 +235,14 @@ async fn close_succeeds_if_only_fin_ack_dropped() {
     //  - Sender is missing the recipient's FIN and times out with failure
     rx_link_up.store(false, Ordering::SeqCst);
 
+    // Since switching to counting one-way FIN-ACK as successful on timeout, If sender sent
+    // fin and everything is acked, but fin the the transfer is considered successful
+    // close after write() now, and close after reading should error.
     match timeout(EXPECTED_IDLE_TIMEOUT * 2, send_stream.close()).await {
-        Ok(Ok(_)) => panic!("Send stream closed successfully, but should have timed out"),
+        Ok(Ok(_)) => {}
         Ok(Err(e)) => {
             // The stream must time out when waiting to close, because recipient's FIN is missing
-            assert_eq!(e.kind(), ErrorKind::TimedOut);
+            panic!("Send stream closed successfully, shouldn't have errored out: {e}");
         }
         Err(e) => {
             panic!("The send stream did not timeout on close() fast enough, giving up after: {e:?}")


### PR DESCRIPTION
This is so clients which support one way acks close successfully.
In this case we are the data sender so if they have acked everything but our fin we will count them as successful. one way acked implementations wouldn't send us a fin so I removed that check for their fin.

With this change at least trace_gossip won't read fluffy transfers as fails and keep trying to resend the content.
This doesn't delay the recv getting the content in anyway as this is a sender's side change.

Of course perfect interop would be nice, but there is no increased delay on receiving data. The only delay is closing the connection to the sender, which can slow down the trace_gossip process, but really isn't that big of a deal