### PR TITLE
fix: was double hashing hashmap key instead of single hashing

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -216,7 +216,7 @@ where
                     Some(Ok(awaiting_key)) = awaiting_expirations.next() => {
                         // accept_with_cid didn't recieve an inbound connection within the timeout period
                         // log it and return a timeout error
-                        if let Some((cid, accept)) = awaiting.remove(&calculate_hash(&awaiting_key)) {
+                        if let Some((cid, accept)) = awaiting.remove(&awaiting_key) {
                             tracing::debug!(%cid.send, %cid.recv, "accept_with_cid timed out");
                             let _ = accept
                                 .stream
@@ -228,7 +228,7 @@ where
                     Some(Ok(incoming_conns_key)) = incoming_conns_expirations.next() => {
                         // didn't handle inbound connection within the timeout period
                         // log it and return a timeout error
-                        if let Some((cid, _)) = incoming_conns.remove(&calculate_hash(&incoming_conns_key)) {
+                        if let Some((cid, _)) = incoming_conns.remove(&incoming_conns_key) {
                             tracing::debug!(%cid.send, %cid.recv, "inbound connection timed out");
                         } else {
                             unreachable!("Error incoming_conns_expirations should always contain valid incoming_conns items")

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -256,7 +256,7 @@ async fn close_succeeds_if_only_fin_ack_dropped() {
             // The stream will already be disconnected by the read_to_eof() call, so we expect a
             // NotConnected error here.
             assert_eq!(e.kind(), ErrorKind::NotConnected);
-        },
+        }
         Err(e) => {
             panic!("The recv stream did not timeout on close() fast enough, giving up after: {e:?}")
         }


### PR DESCRIPTION
```
thread 'tokio-runtime-worker' panicked at /usr/local/cargo/git/checkouts/utp-2d8a743206ecba20/6001fef/src/socket.rs:225:29:
internal error: entered unreachable code: Error awaiting_expirations should always contain valid awaiting items
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This was caused by me double hashing the hashmap key.