### PR TITLE
fix: stop cloning Connection::State as it is very wasteful

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -618,12 +618,9 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
             } => match closing {
                 Some(Closing {
                     local_fin: _,
-                    remote_fin,
-                }) => match remote_fin {
-                    Some(fin) => recv_buf.ack_num() == *fin,
-                    None => false,
-                },
-                None => false,
+                    remote_fin: Some(fin),
+                }) => recv_buf.ack_num() == *fin,
+                _ => false,
             },
             State::Closed { .. } => true,
         }


### PR DESCRIPTION
# Problem
![image](https://github.com/ethereum/utp/assets/31669092/57df2db1-8323-47ca-8854-03afba9f5aae)
This is a flamegraph of trin's heap allocations
Around 85-90+% of our memory allocations look to be caused by uTP making non-needed clones 😱
I am going to do a quick refactor to fix this, but that is crazy

I would take the graph somewhat with a grain of salt because I had to strip some data from the profile to be able to read it as I don't have enough ram to load the full data unstripped

```
You can use the strip subcommand to strip away unnecessary allocations making it possible to load your data file for analysis even if you don't have enough RAM.
```

^ this is what the docs say
> strip away unnecessary allocations

I don't think this would make the result invalid though

As we can see from the picture Conn::shutdown() > clone is taking up like 70% of trins allocations

# Solution

Combining the Established and Closing state into a Connected state.
- It isn't possible to not copy without combining them
- Both Established and Closing state are technically in the Connected state so it is an non-needed distiction 
- Established and Closing state are basically identical through

This refactor will also make it a lot easier for me to debug the infinite memory glitch we currently have