### PR TITLE
fix: remove non-need clone of peer

### DIFF
--- a/src/cid.rs
+++ b/src/cid.rs
@@ -34,6 +34,11 @@ impl<P> StdConnectionIdGenerator<P> {
 
 impl<P: ConnectionPeer> ConnectionIdGenerator<P> for StdConnectionIdGenerator<P> {
     fn cid(&mut self, peer: P, is_initiator: bool) -> ConnectionId<P> {
+        let mut cid = ConnectionId {
+            send: 0,
+            recv: 0,
+            peer,
+        };
         loop {
             let recv: u16 = rand::random();
             let send = if is_initiator {
@@ -41,15 +46,12 @@ impl<P: ConnectionPeer> ConnectionIdGenerator<P> for StdConnectionIdGenerator<P>
             } else {
                 recv.wrapping_sub(1)
             };
-            let cid = ConnectionId {
-                send,
-                recv,
-                peer: peer.clone(),
-            };
+            cid.send = send;
+            cid.recv = recv;
 
             if !self.cids.contains(&cid) {
                 self.cids.insert(cid.clone());
-                break cid;
+                return cid;
             }
         }
     }


### PR DESCRIPTION
Cloning the Enr is very expensive. 
![image](https://github.com/ethereum/utp/assets/31669092/6a406020-6bc5-4419-8f2c-67aa13edeefb)
as seen from this graph

Hopefully we can lower this number in the future as a clone is still taking place, but this is better then nothing for now and signals the direction we are going in.