### PR TITLE
fix: deadlock + memory leak caused by cid generation code

### DIFF
--- a/src/cid.rs
+++ b/src/cid.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::net::SocketAddr;
@@ -13,46 +12,4 @@ pub struct ConnectionId<P> {
     pub send: u16,
     pub recv: u16,
     pub peer: P,
-}
-
-pub trait ConnectionIdGenerator<P> {
-    fn cid(&mut self, peer: P, is_initiator: bool) -> ConnectionId<P>;
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct StdConnectionIdGenerator<P> {
-    cids: HashSet<ConnectionId<P>>,
-}
-
-impl<P> StdConnectionIdGenerator<P> {
-    pub fn new() -> Self {
-        Self {
-            cids: HashSet::new(),
-        }
-    }
-}
-
-impl<P: ConnectionPeer> ConnectionIdGenerator<P> for StdConnectionIdGenerator<P> {
-    fn cid(&mut self, peer: P, is_initiator: bool) -> ConnectionId<P> {
-        let mut cid = ConnectionId {
-            send: 0,
-            recv: 0,
-            peer,
-        };
-        loop {
-            let recv: u16 = rand::random();
-            let send = if is_initiator {
-                recv.wrapping_add(1)
-            } else {
-                recv.wrapping_sub(1)
-            };
-            cid.send = send;
-            cid.recv = recv;
-
-            if !self.cids.contains(&cid) {
-                self.cids.insert(cid.clone());
-                return cid;
-            }
-        }
-    }
 }

--- a/src/congestion.rs
+++ b/src/congestion.rs
@@ -322,7 +322,7 @@ fn compute_max_window_size_adjustment(
     //
     // The base delay adjustment should not panic because the base delay is non-negative and
     // should not be larger than the current delay.
-    let delay_micros = i64::try_from(packet_delay_micros - base_delay_micros).unwrap();
+    let delay_micros = i64::from(packet_delay_micros - base_delay_micros);
 
     let off_target_micros = i64::from(target_delay_micros) - delay_micros;
     let delay_factor = (off_target_micros as f64) / f64::from(target_delay_micros);


### PR DESCRIPTION
# Issue
In Trin we were calling `cid()` which was generating cids and putting them in a Hashset of other CIDs. The issue being this set was isolated and only used for generating cids. So if you accept content from a node enough times you would be stuck in a loop because old values would never be cleared, and there would never be a unique key which didn't exist so you would loop forever, trying to find a cid which didn't already exist. There also was no code to remove cid's from this hashset

This for one created a deadlock because the loop could never escape because a unique cid was impossible, but it also wasted tons of memory because the amount of times you inserted into the Hashset before you deadlocked was tied to the non-random variable aka the peer or in trins case the node id.

So 5 nodes could put 30000k inputs each, but only when 1 node reached Xk inputs would it deadlock.

# How was it fixed

By instead using a unique hashset just for generating unique cids and nothing else. Use the active connections hashmap to tell if a cid is already used or not. The connections hashmap already handles removing and inserting values so this fixes this problem well