### PR TITLE
fix: handle one-way fin edge case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: lint
+lint: # Run clippy and rustfmt
+	cargo fmt --all
+	cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -811,7 +811,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
             closing:
                 Some(Closing {
                     local_fin: Some(local),
-                    remote_fin: None,
+                    remote_fin: _,
                 }),
             sent_packets,
             ..
@@ -828,7 +828,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
         if let State::Connected {
             closing:
                 Some(Closing {
-                    local_fin: None,
+                    local_fin: _,
                     remote_fin: Some(remote),
                 }),
             sent_packets,

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -30,8 +30,15 @@ async fn many_concurrent_transfers() {
     let num_transfers = 1000;
     for i in 0..num_transfers {
         // step up cid by two to avoid collisions
-        let handle =
-            initiate_transfer(i * 2, recv_addr, recv.clone(), send_addr, send.clone(), TEST_DATA).await;
+        let handle = initiate_transfer(
+            i * 2,
+            recv_addr,
+            recv.clone(),
+            send_addr,
+            send.clone(),
+            TEST_DATA,
+        )
+        .await;
         handles.push(handle.0);
         handles.push(handle.1);
     }
@@ -67,8 +74,15 @@ async fn one_huge_data_transfer() {
     let send = Arc::new(send);
 
     let start = Instant::now();
-    let handle =
-        initiate_transfer(0, recv_addr, recv.clone(), send_addr, send.clone(), HUGE_DATA).await;
+    let handle = initiate_transfer(
+        0,
+        recv_addr,
+        recv.clone(),
+        send_addr,
+        send.clone(),
+        HUGE_DATA,
+    )
+    .await;
 
     // Wait for the sending side of the transfer to complete
     handle.0.await.unwrap();
@@ -79,7 +93,12 @@ async fn one_huge_data_transfer() {
     let megabytes_sent = HUGE_DATA.len() as f64 / 1_000_000.0;
     let megabits_sent = megabytes_sent * 8.0;
     let transfer_rate = megabits_sent / elapsed.as_secs_f64();
-    tracing::info!("finished single large transfer test with {:.0} MB, in {:?}, at a rate of {:.1} Mbps", megabytes_sent, elapsed, transfer_rate);
+    tracing::info!(
+        "finished single large transfer test with {:.0} MB, in {:?}, at a rate of {:.1} Mbps",
+        megabytes_sent,
+        elapsed,
+        transfer_rate
+    );
 }
 
 async fn initiate_transfer(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ff5266a7-1e91-47b6-bc5c-e940f08f8131)
![image](https://github.com/user-attachments/assets/a59f9d7a-795c-4754-849a-9e76878260c7)

We support one way finalization's, fluffy had an `optimization` where it would read the data decode the length prefix of the `content value` and try to send an "early" Fin. This "early" Fin would only be sent 0.0001% of the time and it wouldn't acknowledge our Fin as well, so it caused us to timeout.

So we will assume if they send us a pre-mature Fin after we sent our Fin that they are trying to close early and already got the data.

- Kim from Fluffy said they would remove this "early" Fin, as in practice it doesn't improve close times, but can make it work.

But we still need to be able to handle it in the cause someone sends us a malformed flow or something.

Because we use the One way Finalization model, only 1 Fin should ever be sent in total during any transmission. So if there is a `local_fin` and a `remote_fin` that would be unexpected.