### PR TITLE
refactor!: simplify UtpSocket api

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -185,9 +185,9 @@ where
                         }
                     }
                     Some(Ok((cid, accept))) = awaiting.next() => {
-                        // accept_with_cid didn't receive an inbound connection within the timeout period
+                        // accept didn't receive an inbound connection within the timeout period
                         // log it and return a timeout error
-                        tracing::debug!(%cid.send, %cid.recv, "accept_with_cid timed out");
+                        tracing::debug!(%cid.send, %cid.recv, "accept timed out");
                         let _ = accept
                             .stream
                             .send(Err(io::Error::from(io::ErrorKind::TimedOut)));
@@ -236,7 +236,7 @@ where
         self.conns.read().unwrap().len()
     }
 
-    pub async fn accept_with_cid(
+    pub async fn accept(
         &self,
         cid: ConnectionId<P>,
         config: ConnectionConfig,
@@ -255,7 +255,7 @@ where
         }
     }
 
-    pub async fn connect_with_cid(
+    pub async fn connect(
         &self,
         cid: ConnectionId<P>,
         config: ConnectionConfig,

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -124,7 +124,7 @@ async fn initiate_transfer(
     };
 
     let recv_handle = tokio::spawn(async move {
-        let mut stream = recv.accept_with_cid(recv_cid, conn_config).await.unwrap();
+        let mut stream = recv.accept(recv_cid, conn_config).await.unwrap();
         let mut buf = vec![];
         let n = match stream.read_to_eof(&mut buf).await {
             Ok(num_bytes) => num_bytes,
@@ -141,7 +141,7 @@ async fn initiate_transfer(
     });
 
     let send_handle = tokio::spawn(async move {
-        let mut stream = send.connect_with_cid(send_cid, conn_config).await.unwrap();
+        let mut stream = send.connect(send_cid, conn_config).await.unwrap();
         let n = stream.write(data).await.unwrap();
         assert_eq!(n, data.len());
 
@@ -183,20 +183,12 @@ async fn test_socket_reports_two_connections() {
     };
 
     let recv_one = Arc::clone(&recv);
-    let recv_one_handle = tokio::spawn(async move {
-        recv_one
-            .accept_with_cid(recv_one_cid, conn_config)
-            .await
-            .unwrap()
-    });
+    let recv_one_handle =
+        tokio::spawn(async move { recv_one.accept(recv_one_cid, conn_config).await.unwrap() });
 
     let send_one = Arc::clone(&send);
-    let send_one_handle = tokio::spawn(async move {
-        send_one
-            .connect_with_cid(send_one_cid, conn_config)
-            .await
-            .unwrap()
-    });
+    let send_one_handle =
+        tokio::spawn(async move { send_one.connect(send_one_cid, conn_config).await.unwrap() });
 
     let recv_two_cid = cid::ConnectionId {
         send: 200,
@@ -210,20 +202,12 @@ async fn test_socket_reports_two_connections() {
     };
 
     let recv_two = Arc::clone(&recv);
-    let recv_two_handle = tokio::spawn(async move {
-        recv_two
-            .accept_with_cid(recv_two_cid, conn_config)
-            .await
-            .unwrap()
-    });
+    let recv_two_handle =
+        tokio::spawn(async move { recv_two.accept(recv_two_cid, conn_config).await.unwrap() });
 
     let send_two = Arc::clone(&send);
-    let send_two_handle = tokio::spawn(async move {
-        send_two
-            .connect_with_cid(send_two_cid, conn_config)
-            .await
-            .unwrap()
-    });
+    let send_two_handle =
+        tokio::spawn(async move { send_two.connect(send_two_cid, conn_config).await.unwrap() });
 
     let (tx_one, rx_one, tx_two, rx_two) = tokio::join!(
         send_one_handle,

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -27,22 +27,14 @@ async fn close_is_successful_when_write_completes() {
     let send = Arc::new(send);
 
     let recv_one = Arc::clone(&recv);
-    let recv_one_handle = tokio::spawn(async move {
-        recv_one
-            .accept_with_cid(recv_cid, conn_config)
-            .await
-            .unwrap()
-    });
+    let recv_one_handle =
+        tokio::spawn(async move { recv_one.accept(recv_cid, conn_config).await.unwrap() });
 
     // Keep a clone of the socket so that it doesn't drop when moved into the task.
     // Dropping it causes all connections to exit.
     let send_one = Arc::clone(&send);
-    let send_one_handle = tokio::spawn(async move {
-        send_one
-            .connect_with_cid(send_cid, conn_config)
-            .await
-            .unwrap()
-    });
+    let send_one_handle =
+        tokio::spawn(async move { send_one.connect(send_cid, conn_config).await.unwrap() });
 
     let (tx_one, rx_one) = tokio::join!(send_one_handle, recv_one_handle,);
     let mut send_stream = tx_one.unwrap();
@@ -98,22 +90,14 @@ async fn close_errors_if_all_packets_dropped() {
     let send = Arc::new(send);
 
     let recv_one = Arc::clone(&recv);
-    let recv_one_handle = tokio::spawn(async move {
-        recv_one
-            .accept_with_cid(recv_cid, conn_config)
-            .await
-            .unwrap()
-    });
+    let recv_one_handle =
+        tokio::spawn(async move { recv_one.accept(recv_cid, conn_config).await.unwrap() });
 
     // Keep a clone of the socket so that it doesn't drop when moved into the task.
     // Dropping it causes all connections to exit.
     let send_one = Arc::clone(&send);
-    let send_one_handle = tokio::spawn(async move {
-        send_one
-            .connect_with_cid(send_cid, conn_config)
-            .await
-            .unwrap()
-    });
+    let send_one_handle =
+        tokio::spawn(async move { send_one.connect(send_cid, conn_config).await.unwrap() });
 
     let (tx_one, rx_one) = tokio::join!(send_one_handle, recv_one_handle,);
     let mut send_stream = tx_one.unwrap();
@@ -176,22 +160,14 @@ async fn close_succeeds_if_only_fin_ack_dropped() {
     let send = Arc::new(send);
 
     let recv_one = Arc::clone(&recv);
-    let recv_one_handle = tokio::spawn(async move {
-        recv_one
-            .accept_with_cid(recv_cid, conn_config)
-            .await
-            .unwrap()
-    });
+    let recv_one_handle =
+        tokio::spawn(async move { recv_one.accept(recv_cid, conn_config).await.unwrap() });
 
     // Keep a clone of the socket so that it doesn't drop when moved into the task.
     // Dropping it causes all connections to exit.
     let send_one = Arc::clone(&send);
-    let send_one_handle = tokio::spawn(async move {
-        send_one
-            .connect_with_cid(send_cid, conn_config)
-            .await
-            .unwrap()
-    });
+    let send_one_handle =
+        tokio::spawn(async move { send_one.connect(send_cid, conn_config).await.unwrap() });
 
     let (tx_one, rx_one) = tokio::join!(send_one_handle, recv_one_handle,);
     let mut send_stream = tx_one.unwrap();


### PR DESCRIPTION
Remove `accept`/`connect` in favor of `accept_with_cid`/`connect_with_cid` (which are renamed to `accept`/`connect`).

This is needed in order to fix ethereum/trin#1596, which will be done in future PR.

Also simplified tracking of accepted and incoming connections: using `HashMapDelay` instead of `HashMap+HashSetDelay` combination.