### PR TITLE
feat!: distinguish peer and peer_id on api level

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,4 @@ workflows:
       - rust/lint-test-build:
           clippy_arguments: '--all-targets --all-features -- --deny warnings'
           release: true
-          version: 1.71.1
-
+          version: 1.81.0

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -1,15 +1,6 @@
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::net::SocketAddr;
-
-/// A remote peer.
-pub trait ConnectionPeer: Clone + Debug + Eq + Hash + PartialEq + Send + Sync {}
-
-impl ConnectionPeer for SocketAddr {}
-
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub struct ConnectionId<P> {
     pub send: u16,
     pub recv: u16,
-    pub peer: P,
+    pub peer_id: P,
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -8,10 +8,12 @@ use delay_map::HashMapDelay;
 use futures::StreamExt;
 use tokio::sync::{mpsc, oneshot, Notify};
 
-use crate::cid::{ConnectionId, ConnectionPeer};
+use crate::cid::ConnectionId;
 use crate::congestion;
 use crate::event::{SocketEvent, StreamEvent};
 use crate::packet::{Packet, PacketBuilder, PacketType, SelectiveAck};
+use crate::peer::ConnectionPeer;
+use crate::peer::Peer;
 use crate::recv::ReceiveBuffer;
 use crate::send::SendBuffer;
 use crate::sent::{SentPackets, SentPacketsError};
@@ -167,9 +169,10 @@ impl From<ConnectionConfig> for congestion::Config {
     }
 }
 
-pub struct Connection<const N: usize, P> {
+pub struct Connection<const N: usize, P: ConnectionPeer> {
     state: State<N>,
-    cid: ConnectionId<P>,
+    cid: ConnectionId<P::Id>,
+    peer: Peer<P>,
     config: ConnectionConfig,
     endpoint: Endpoint,
     peer_ts_diff: Duration,
@@ -185,7 +188,8 @@ pub struct Connection<const N: usize, P> {
 
 impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
     pub fn new(
-        cid: ConnectionId<P>,
+        cid: ConnectionId<P::Id>,
+        peer: Peer<P>,
         config: ConnectionConfig,
         syn: Option<Packet>,
         connected: oneshot::Sender<io::Result<()>>,
@@ -212,6 +216,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
         Self {
             state: State::Connecting(Some(connected)),
             cid,
+            peer,
             config,
             endpoint,
             peer_ts_diff,
@@ -232,7 +237,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
         mut writes: mpsc::UnboundedReceiver<Write>,
         mut shutdown: oneshot::Receiver<()>,
     ) -> io::Result<()> {
-        tracing::debug!("uTP conn starting... {:?}", self.cid.peer);
+        tracing::debug!("uTP conn starting... {:?}", self.cid.peer_id);
 
         // If we are the initiating endpoint, then send the SYN. If we are the accepting endpoint,
         // then send the SYN-ACK.
@@ -240,7 +245,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
             Endpoint::Initiator((syn_seq_num, ..)) => {
                 let syn = self.syn_packet(syn_seq_num);
                 self.socket_events
-                    .send(SocketEvent::Outgoing((syn.clone(), self.cid.peer.clone())))
+                    .send(SocketEvent::Outgoing((syn.clone(), self.peer.clone())))
                     .unwrap();
                 self.unacked
                     .insert_at(syn_seq_num, syn, self.config.initial_timeout);
@@ -250,7 +255,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
             Endpoint::Acceptor((syn, syn_ack)) => {
                 let state = self.state_packet().unwrap();
                 self.socket_events
-                    .send(SocketEvent::Outgoing((state, self.cid.peer.clone())))
+                    .send(SocketEvent::Outgoing((state, self.peer.clone())))
                     .unwrap();
 
                 let recv_buf = ReceiveBuffer::new(syn);
@@ -409,7 +414,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                                 &mut self.unacked,
                                 &mut self.socket_events,
                                 fin,
-                                &self.cid.peer,
+                                &self.peer,
                                 Instant::now(),
                             );
                         }
@@ -441,7 +446,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                                 &mut self.unacked,
                                 &mut self.socket_events,
                                 fin,
-                                &self.cid.peer,
+                                &self.peer,
                                 Instant::now(),
                             );
                         }
@@ -542,7 +547,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                 &mut self.unacked,
                 &mut self.socket_events,
                 packet,
-                &self.cid.peer,
+                &self.peer,
                 now,
             );
             seq_num = seq_num.wrapping_add(1);
@@ -680,7 +685,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                         let packet = self.syn_packet(seq);
                         let _ = self
                             .socket_events
-                            .send(SocketEvent::Outgoing((packet, self.cid.peer.clone())));
+                            .send(SocketEvent::Outgoing((packet, self.peer.clone())));
                     }
                 }
                 Endpoint::Acceptor(..) => {}
@@ -728,7 +733,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                     &mut self.unacked,
                     &mut self.socket_events,
                     packet,
-                    &self.cid.peer,
+                    &self.peer,
                     now,
                 );
             }
@@ -784,7 +789,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
         match packet.packet_type() {
             PacketType::Syn | PacketType::Fin | PacketType::Data => {
                 if let Some(state) = self.state_packet() {
-                    let event = SocketEvent::Outgoing((state, self.cid.peer.clone()));
+                    let event = SocketEvent::Outgoing((state, self.peer.clone()));
                     if self.socket_events.send(event).is_err() {
                         tracing::warn!("Cannot transmit state packet: socket closed channel");
                         return;
@@ -1156,7 +1161,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                 &mut self.unacked,
                 &mut self.socket_events,
                 packet,
-                &self.cid.peer,
+                &self.peer,
                 now,
             );
         }
@@ -1167,7 +1172,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
         unacked: &mut HashMapDelay<u16, Packet>,
         socket_events: &mut mpsc::UnboundedSender<SocketEvent<P>>,
         packet: Packet,
-        dest: &P,
+        peer: &Peer<P>,
         now: Instant,
     ) {
         let (payload, len) = if packet.payload().is_empty() {
@@ -1189,7 +1194,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
 
         sent_packets.on_transmit(packet.seq_num(), packet.packet_type(), payload, len, now);
         unacked.insert_at(packet.seq_num(), packet.clone(), sent_packets.timeout());
-        let outbound = SocketEvent::Outgoing((packet, dest.clone()));
+        let outbound = SocketEvent::Outgoing((packet, peer.clone()));
         if socket_events.send(outbound).is_err() {
             tracing::warn!("Cannot transmit packet: socket closed channel");
         }
@@ -1214,12 +1219,13 @@ mod test {
         let cid = ConnectionId {
             send: 101,
             recv: 100,
-            peer,
+            peer_id: peer,
         };
 
         Connection {
             state: State::Connecting(Some(connected)),
             cid,
+            peer: Peer::new(peer),
             config: ConnectionConfig::default(),
             endpoint,
             peer_ts_diff: Duration::from_millis(100),

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -237,7 +237,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
         mut writes: mpsc::UnboundedReceiver<Write>,
         mut shutdown: oneshot::Receiver<()>,
     ) -> io::Result<()> {
-        tracing::debug!("uTP conn starting... {:?}", self.cid.peer_id);
+        tracing::debug!("uTP conn starting... {:?}", self.peer);
 
         // If we are the initiating endpoint, then send the SYN. If we are the accepting endpoint,
         // then send the SYN-ACK.

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,6 @@
 use crate::cid::ConnectionId;
 use crate::packet::Packet;
+use crate::peer::{ConnectionPeer, Peer};
 
 #[derive(Clone, Debug)]
 pub enum StreamEvent {
@@ -8,7 +9,7 @@ pub enum StreamEvent {
 }
 
 #[derive(Clone, Debug)]
-pub enum SocketEvent<P> {
-    Outgoing((Packet, P)),
-    Shutdown(ConnectionId<P>),
+pub enum SocketEvent<P: ConnectionPeer> {
+    Outgoing((Packet, Peer<P>)),
+    Shutdown(ConnectionId<P::Id>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod congestion;
 pub mod conn;
 pub mod event;
 pub mod packet;
+pub mod peer;
 pub mod recv;
 pub mod send;
 pub mod sent;

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,0 +1,81 @@
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::net::SocketAddr;
+
+/// A trait that describes remote peer
+pub trait ConnectionPeer: Debug + Clone + Send + Sync {
+    type Id: Debug + Clone + PartialEq + Eq + Hash + Send + Sync;
+
+    /// Returns peer's id
+    fn id(&self) -> Self::Id;
+
+    /// Merge the given object into `Self` whilst consuming it.
+    ///
+    /// Should panic if ids are not matching.
+    fn merge(&mut self, other: Self);
+}
+
+impl ConnectionPeer for SocketAddr {
+    type Id = Self;
+
+    fn id(&self) -> Self::Id {
+        *self
+    }
+
+    fn merge(&mut self, other: Self) {
+        assert!(self == &other)
+    }
+}
+
+/// Structure that stores peer's id, and maybe peer as well.
+#[derive(Debug, Clone)]
+pub struct Peer<P: ConnectionPeer> {
+    id: P::Id,
+    peer: Option<P>,
+}
+
+impl<P: ConnectionPeer> Peer<P> {
+    /// Creates new instance that stores peer
+    pub fn new(peer: P) -> Self {
+        Self {
+            id: peer.id(),
+            peer: Some(peer),
+        }
+    }
+
+    /// Creates new instance that only stores peer's id
+    pub fn new_id(peer_id: P::Id) -> Self {
+        Self {
+            id: peer_id,
+            peer: None,
+        }
+    }
+
+    /// Returns peer's id
+    pub fn id(&self) -> &P::Id {
+        &self.id
+    }
+
+    /// Returns optional reference to peer
+    pub fn peer(&self) -> Option<&P> {
+        self.peer.as_ref()
+    }
+
+    /// Merge the given peer into `Self` whilst consuming it.
+    ///
+    /// Panics if ids are not matching.
+    pub fn merge(&mut self, other: Self) {
+        assert!(self.id == other.id);
+        let Some(other_peer) = other.peer else {
+            return;
+        };
+
+        self.peer = match self.peer.take() {
+            Some(mut peer) => {
+                peer.merge(other_peer);
+                Some(peer)
+            }
+            None => Some(other_peer),
+        };
+    }
+}

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -121,7 +121,7 @@ where
                                     // create a new stream for that connection. Otherwise, add the
                                     // connection to the incoming connections.
                                     if let Some(accept_with_cid) = awaiting.remove(&cid) {
-                                        peer.merge(accept_with_cid.peer);
+                                        peer.consolidate(accept_with_cid.peer);
 
                                         let (connected_tx, connected_rx) = oneshot::channel();
                                         let (events_tx, events_rx) = mpsc::unbounded_channel();
@@ -177,7 +177,7 @@ where
                             awaiting.insert(accept_with_cid.cid.clone(), accept_with_cid);
                             continue;
                         };
-                        peer.merge(accept_with_cid.peer);
+                        peer.consolidate(accept_with_cid.peer);
                         Self::select_accept_helper(accept_with_cid.cid, peer, syn, conns.clone(), accept_with_cid.accept, socket_event_tx.clone());
                     }
                     Some(accept) = accepts_rx.recv(), if !incoming_conns.is_empty() => {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -11,18 +11,25 @@ use tokio::net::UdpSocket;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{mpsc, oneshot};
 
-use crate::cid::{ConnectionId, ConnectionPeer};
+use crate::cid::ConnectionId;
 use crate::conn::ConnectionConfig;
 use crate::event::{SocketEvent, StreamEvent};
 use crate::packet::{Packet, PacketBuilder, PacketType};
+use crate::peer::{ConnectionPeer, Peer};
 use crate::stream::UtpStream;
 use crate::udp::AsyncUdpSocket;
 
 type ConnChannel = UnboundedSender<StreamEvent>;
 
-struct Accept<P> {
+struct Accept<P: ConnectionPeer> {
     stream: oneshot::Sender<io::Result<UtpStream<P>>>,
     config: ConnectionConfig,
+}
+
+struct AcceptWithCidPeer<P: ConnectionPeer> {
+    cid: ConnectionId<P::Id>,
+    peer: Peer<P>,
+    accept: Accept<P>,
 }
 
 const MAX_UDP_PAYLOAD_SIZE: usize = u16::MAX as usize;
@@ -36,10 +43,10 @@ const CID_GENERATION_TRY_WARNING_COUNT: usize = 10;
 /// but thee uTP config refactor is currently very low priority.
 const AWAITING_CONNECTION_TIMEOUT: Duration = Duration::from_secs(20);
 
-pub struct UtpSocket<P> {
-    conns: Arc<RwLock<HashMap<ConnectionId<P>, ConnChannel>>>,
+pub struct UtpSocket<P: ConnectionPeer> {
+    conns: Arc<RwLock<HashMap<ConnectionId<P::Id>, ConnChannel>>>,
     accepts: UnboundedSender<Accept<P>>,
-    accepts_with_cid: UnboundedSender<(Accept<P>, ConnectionId<P>)>,
+    accepts_with_cid: UnboundedSender<AcceptWithCidPeer<P>>,
     socket_events: UnboundedSender<SocketEvent<P>>,
 }
 
@@ -53,7 +60,7 @@ impl UtpSocket<SocketAddr> {
 
 impl<P> UtpSocket<P>
 where
-    P: ConnectionPeer + Unpin + 'static,
+    P: ConnectionPeer<Id: Unpin> + Unpin + 'static,
 {
     pub fn with_socket<S>(mut socket: S) -> Self
     where
@@ -62,10 +69,10 @@ where
         let conns = HashMap::new();
         let conns = Arc::new(RwLock::new(conns));
 
-        let mut awaiting: HashMapDelay<ConnectionId<P>, Accept<P>> =
+        let mut awaiting: HashMapDelay<ConnectionId<P::Id>, AcceptWithCidPeer<P>> =
             HashMapDelay::new(AWAITING_CONNECTION_TIMEOUT);
 
-        let mut incoming_conns: HashMapDelay<ConnectionId<P>, Packet> =
+        let mut incoming_conns: HashMapDelay<ConnectionId<P::Id>, (Peer<P>, Packet)> =
             HashMapDelay::new(AWAITING_CONNECTION_TIMEOUT);
 
         let (socket_event_tx, mut socket_event_rx) = mpsc::unbounded_channel();
@@ -84,18 +91,19 @@ where
             loop {
                 tokio::select! {
                     biased;
-                    Ok((n, src)) = socket.recv_from(&mut buf) => {
+                    Ok((n, mut peer)) = socket.recv_from(&mut buf) => {
+                        let peer_id = peer.id();
                         let packet = match Packet::decode(&buf[..n]) {
                             Ok(pkt) => pkt,
                             Err(..) => {
-                                tracing::warn!(?src, "unable to decode uTP packet");
+                                tracing::warn!(?peer_id, "unable to decode uTP packet");
                                 continue;
                             }
                         };
 
-                        let peer_init_cid = cid_from_packet(&packet, &src, IdType::SendIdPeerInitiated);
-                        let we_init_cid = cid_from_packet(&packet, &src, IdType::SendIdWeInitiated);
-                        let acc_cid = cid_from_packet(&packet, &src, IdType::RecvId);
+                        let peer_init_cid = cid_from_packet::<P>(&packet, peer_id, IdType::SendIdPeerInitiated);
+                        let we_init_cid = cid_from_packet::<P>(&packet, peer_id, IdType::SendIdWeInitiated);
+                        let acc_cid = cid_from_packet::<P>(&packet, peer_id, IdType::RecvId);
                         let mut conns = conns.write().unwrap();
                         let conn = conns
                             .get(&acc_cid)
@@ -107,12 +115,14 @@ where
                             }
                             None => {
                                 if std::matches!(packet.packet_type(), PacketType::Syn) {
-                                    let cid = cid_from_packet(&packet, &src, IdType::RecvId);
+                                    let cid = cid_from_packet::<P>(&packet, peer_id, IdType::RecvId);
 
                                     // If there was an awaiting connection with the CID, then
                                     // create a new stream for that connection. Otherwise, add the
                                     // connection to the incoming connections.
-                                    if let Some(accept) = awaiting.remove(&cid) {
+                                    if let Some(accept_with_cid) = awaiting.remove(&cid) {
+                                        peer.merge(accept_with_cid.peer);
+
                                         let (connected_tx, connected_rx) = oneshot::channel();
                                         let (events_tx, events_rx) = mpsc::unbounded_channel();
 
@@ -120,7 +130,8 @@ where
 
                                         let stream = UtpStream::new(
                                             cid,
-                                            accept.config,
+                                            peer,
+                                            accept_with_cid.accept.config,
                                             Some(packet),
                                             socket_event_tx.clone(),
                                             events_rx,
@@ -128,10 +139,10 @@ where
                                         );
 
                                         tokio::spawn(async move {
-                                            Self::await_connected(stream, accept, connected_rx).await
+                                            Self::await_connected(stream, accept_with_cid.accept.stream, connected_rx).await
                                         });
                                     } else {
-                                        incoming_conns.insert(cid, packet);
+                                        incoming_conns.insert(cid, (peer, packet));
                                     }
                                 } else {
                                     tracing::debug!(
@@ -151,7 +162,7 @@ where
                                         let reset_packet =
                                             PacketBuilder::new(PacketType::Reset, packet.conn_id(), crate::time::now_micros(), 100_000, random_seq_num)
                                                 .build();
-                                        let event = SocketEvent::Outgoing((reset_packet, src.clone()));
+                                        let event = SocketEvent::Outgoing((reset_packet, peer));
                                         if socket_event_tx.send(event).is_err() {
                                             tracing::warn!("Cannot transmit reset packet: socket closed channel");
                                             return;
@@ -161,18 +172,19 @@ where
                             },
                         }
                     }
-                    Some((accept, cid)) = accepts_with_cid_rx.recv() => {
-                        let Some(syn) = incoming_conns.remove(&cid) else {
-                            awaiting.insert(cid, accept);
+                    Some(accept_with_cid) = accepts_with_cid_rx.recv() => {
+                        let Some((mut peer, syn)) = incoming_conns.remove(&accept_with_cid.cid) else {
+                            awaiting.insert(accept_with_cid.cid.clone(), accept_with_cid);
                             continue;
                         };
-                        Self::select_accept_helper(cid, syn, conns.clone(), accept, socket_event_tx.clone());
+                        peer.merge(accept_with_cid.peer);
+                        Self::select_accept_helper(accept_with_cid.cid, peer, syn, conns.clone(), accept_with_cid.accept, socket_event_tx.clone());
                     }
                     Some(accept) = accepts_rx.recv(), if !incoming_conns.is_empty() => {
-                        let (cid, _) = incoming_conns.iter().next().expect("at least one incoming connection");
+                        let cid = incoming_conns.keys().next().expect("at least one incoming connection");
                         let cid = cid.clone();
-                        let packet = incoming_conns.remove(&cid).expect("to delete incoming connection");
-                        Self::select_accept_helper(cid, packet, conns.clone(), accept, socket_event_tx.clone());
+                        let (peer, packet) = incoming_conns.remove(&cid).expect("to delete incoming connection");
+                        Self::select_accept_helper(cid, peer, packet, conns.clone(), accept, socket_event_tx.clone());
                     }
                     Some(event) = socket_event_rx.recv() => {
                         match event {
@@ -195,11 +207,11 @@ where
                             }
                         }
                     }
-                    Some(Ok((cid, accept))) = awaiting.next() => {
+                    Some(Ok((cid, accept_with_cid))) = awaiting.next() => {
                         // accept_with_cid didn't receive an inbound connection within the timeout period
                         // log it and return a timeout error
                         tracing::debug!(%cid.send, %cid.recv, "accept_with_cid timed out");
-                        let _ = accept
+                        let _ = accept_with_cid.accept
                             .stream
                             .send(Err(io::Error::from(io::ErrorKind::TimedOut)));
                     }
@@ -218,14 +230,14 @@ where
     /// Internal cid generation
     fn generate_cid(
         &self,
-        peer: P,
+        peer_id: P::Id,
         is_initiator: bool,
         event_tx: Option<UnboundedSender<StreamEvent>>,
-    ) -> ConnectionId<P> {
+    ) -> ConnectionId<P::Id> {
         let mut cid = ConnectionId {
             send: 0,
             recv: 0,
-            peer,
+            peer_id,
         };
         let mut generation_attempt_count = 0;
         loop {
@@ -251,8 +263,8 @@ where
         }
     }
 
-    pub fn cid(&self, peer: P, is_initiator: bool) -> ConnectionId<P> {
-        self.generate_cid(peer, is_initiator, None)
+    pub fn cid(&self, peer_id: P::Id, is_initiator: bool) -> ConnectionId<P::Id> {
+        self.generate_cid(peer_id, is_initiator, None)
     }
 
     /// Returns the number of connections currently open, both inbound and outbound.
@@ -281,16 +293,21 @@ where
     /// they aren't compatible to use interchangeably in a program
     pub async fn accept_with_cid(
         &self,
-        cid: ConnectionId<P>,
+        cid: ConnectionId<P::Id>,
+        peer: Peer<P>,
         config: ConnectionConfig,
     ) -> io::Result<UtpStream<P>> {
         let (stream_tx, stream_rx) = oneshot::channel();
-        let accept = Accept {
-            stream: stream_tx,
-            config,
+        let accept = AcceptWithCidPeer {
+            cid,
+            peer,
+            accept: Accept {
+                stream: stream_tx,
+                config,
+            },
         };
         self.accepts_with_cid
-            .send((accept, cid))
+            .send(accept)
             .map_err(|_| io::Error::from(io::ErrorKind::NotConnected))?;
         match stream_rx.await {
             Ok(stream) => Ok(stream?),
@@ -298,13 +315,18 @@ where
         }
     }
 
-    pub async fn connect(&self, peer: P, config: ConnectionConfig) -> io::Result<UtpStream<P>> {
+    pub async fn connect(
+        &self,
+        peer: Peer<P>,
+        config: ConnectionConfig,
+    ) -> io::Result<UtpStream<P>> {
         let (connected_tx, connected_rx) = oneshot::channel();
         let (events_tx, events_rx) = mpsc::unbounded_channel();
-        let cid = self.generate_cid(peer, true, Some(events_tx));
+        let cid = self.generate_cid(peer.id().clone(), true, Some(events_tx));
 
         let stream = UtpStream::new(
             cid,
+            peer,
             config,
             None,
             self.socket_events.clone(),
@@ -321,7 +343,8 @@ where
 
     pub async fn connect_with_cid(
         &self,
-        cid: ConnectionId<P>,
+        cid: ConnectionId<P::Id>,
+        peer: Peer<P>,
         config: ConnectionConfig,
     ) -> io::Result<UtpStream<P>> {
         if self.conns.read().unwrap().contains_key(&cid) {
@@ -340,6 +363,7 @@ where
 
         let stream = UtpStream::new(
             cid.clone(),
+            peer,
             config,
             None,
             self.socket_events.clone(),
@@ -362,28 +386,27 @@ where
 
     async fn await_connected(
         stream: UtpStream<P>,
-        accept: Accept<P>,
+        callback: oneshot::Sender<io::Result<UtpStream<P>>>,
         connected: oneshot::Receiver<io::Result<()>>,
     ) {
         match connected.await {
             Ok(Ok(..)) => {
-                let _ = accept.stream.send(Ok(stream));
+                let _ = callback.send(Ok(stream));
             }
             Ok(Err(err)) => {
-                let _ = accept.stream.send(Err(err));
+                let _ = callback.send(Err(err));
             }
             Err(..) => {
-                let _ = accept
-                    .stream
-                    .send(Err(io::Error::from(io::ErrorKind::ConnectionAborted)));
+                let _ = callback.send(Err(io::Error::from(io::ErrorKind::ConnectionAborted)));
             }
         }
     }
 
     fn select_accept_helper(
-        cid: ConnectionId<P>,
+        cid: ConnectionId<P::Id>,
+        peer: Peer<P>,
         syn: Packet,
-        conns: Arc<RwLock<HashMap<ConnectionId<P>, UnboundedSender<StreamEvent>>>>,
+        conns: Arc<RwLock<HashMap<ConnectionId<P::Id>, ConnChannel>>>,
         accept: Accept<P>,
         socket_event_tx: UnboundedSender<SocketEvent<P>>,
     ) {
@@ -404,6 +427,7 @@ where
 
         let stream = UtpStream::new(
             cid,
+            peer,
             accept.config,
             Some(syn),
             socket_event_tx,
@@ -411,7 +435,9 @@ where
             connected_tx,
         );
 
-        tokio::spawn(async move { Self::await_connected(stream, accept, connected_rx).await });
+        tokio::spawn(
+            async move { Self::await_connected(stream, accept.stream, connected_rx).await },
+        );
     }
 }
 
@@ -424,9 +450,10 @@ enum IdType {
 
 fn cid_from_packet<P: ConnectionPeer>(
     packet: &Packet,
-    src: &P,
+    peer_id: &P::Id,
     id_type: IdType,
-) -> ConnectionId<P> {
+) -> ConnectionId<P::Id> {
+    let peer_id = peer_id.clone();
     match id_type {
         IdType::RecvId => {
             let (send, recv) = match packet.packet_type() {
@@ -438,7 +465,7 @@ fn cid_from_packet<P: ConnectionPeer>(
             ConnectionId {
                 send,
                 recv,
-                peer: src.clone(),
+                peer_id,
             }
         }
         IdType::SendIdWeInitiated => {
@@ -446,7 +473,7 @@ fn cid_from_packet<P: ConnectionPeer>(
             ConnectionId {
                 send,
                 recv,
-                peer: src.clone(),
+                peer_id,
             }
         }
         IdType::SendIdPeerInitiated => {
@@ -454,13 +481,13 @@ fn cid_from_packet<P: ConnectionPeer>(
             ConnectionId {
                 send,
                 recv,
-                peer: src.clone(),
+                peer_id,
             }
         }
     }
 }
 
-impl<P> Drop for UtpSocket<P> {
+impl<P: ConnectionPeer> Drop for UtpSocket<P> {
     fn drop(&mut self) {
         for conn in self.conns.read().unwrap().values() {
             let _ = conn.send(StreamEvent::Shutdown);

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -96,7 +96,7 @@ where
                         let packet = match Packet::decode(&buf[..n]) {
                             Ok(pkt) => pkt,
                             Err(..) => {
-                                tracing::warn!(?peer_id, "unable to decode uTP packet");
+                                tracing::warn!(?peer, "unable to decode uTP packet");
                                 continue;
                             }
                         };
@@ -115,7 +115,7 @@ where
                             }
                             None => {
                                 if std::matches!(packet.packet_type(), PacketType::Syn) {
-                                    let cid = cid_from_packet::<P>(&packet, peer_id, IdType::RecvId);
+                                    let cid = acc_cid;
 
                                     // If there was an awaiting connection with the CID, then
                                     // create a new stream for that connection. Otherwise, add the

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -81,8 +81,9 @@ impl ConnectionPeer for char {
         *self
     }
 
-    fn merge(&mut self, other: Self) {
-        assert!(*self == other)
+    fn consolidate(a: Self, b: Self) -> Self {
+        assert!(a == b, "Consolidating non-equal peers");
+        a
     }
 }
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -4,25 +4,27 @@ use std::net::SocketAddr;
 use async_trait::async_trait;
 use tokio::net::UdpSocket;
 
-use crate::cid::ConnectionPeer;
+use crate::peer::{ConnectionPeer, Peer};
 
 /// An abstract representation of an asynchronous UDP socket.
 #[async_trait]
 pub trait AsyncUdpSocket<P: ConnectionPeer>: Send + Sync {
-    /// Attempts to send data on the socket to a given address.
+    /// Attempts to send data on the socket to a given peer.
     /// Note that this should return nearly immediately, rather than awaiting something internally.
-    async fn send_to(&mut self, buf: &[u8], target: &P) -> io::Result<usize>;
+    async fn send_to(&mut self, buf: &[u8], peer: &Peer<P>) -> io::Result<usize>;
     /// Attempts to receive a single datagram on the socket.
-    async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, P)>;
+    async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, Peer<P>)>;
 }
 
 #[async_trait]
 impl AsyncUdpSocket<SocketAddr> for UdpSocket {
-    async fn send_to(&mut self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
-        UdpSocket::send_to(self, buf, target).await
+    async fn send_to(&mut self, buf: &[u8], peer: &Peer<SocketAddr>) -> io::Result<usize> {
+        UdpSocket::send_to(self, buf, peer.id()).await
     }
 
-    async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
-        UdpSocket::recv_from(self, buf).await
+    async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, Peer<SocketAddr>)> {
+        UdpSocket::recv_from(self, buf)
+            .await
+            .map(|(len, peer)| (len, Peer::new(peer)))
     }
 }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use tokio::time::timeout;
 
 use utp_rs::conn::{ConnectionConfig, DEFAULT_MAX_IDLE_TIMEOUT};
+use utp_rs::peer::Peer;
 use utp_rs::socket::UtpSocket;
 
 use utp_rs::testutils;
@@ -29,7 +30,7 @@ async fn close_is_successful_when_write_completes() {
     let recv_one = Arc::clone(&recv);
     let recv_one_handle = tokio::spawn(async move {
         recv_one
-            .accept_with_cid(recv_cid, conn_config)
+            .accept_with_cid(recv_cid, Peer::new_id(recv_cid.peer_id), conn_config)
             .await
             .unwrap()
     });
@@ -39,7 +40,7 @@ async fn close_is_successful_when_write_completes() {
     let send_one = Arc::clone(&send);
     let send_one_handle = tokio::spawn(async move {
         send_one
-            .connect_with_cid(send_cid, conn_config)
+            .connect_with_cid(send_cid, Peer::new_id(send_cid.peer_id), conn_config)
             .await
             .unwrap()
     });
@@ -100,7 +101,7 @@ async fn close_errors_if_all_packets_dropped() {
     let recv_one = Arc::clone(&recv);
     let recv_one_handle = tokio::spawn(async move {
         recv_one
-            .accept_with_cid(recv_cid, conn_config)
+            .accept_with_cid(recv_cid, Peer::new_id(recv_cid.peer_id), conn_config)
             .await
             .unwrap()
     });
@@ -110,7 +111,7 @@ async fn close_errors_if_all_packets_dropped() {
     let send_one = Arc::clone(&send);
     let send_one_handle = tokio::spawn(async move {
         send_one
-            .connect_with_cid(send_cid, conn_config)
+            .connect_with_cid(send_cid, Peer::new_id(send_cid.peer_id), conn_config)
             .await
             .unwrap()
     });
@@ -178,7 +179,7 @@ async fn close_succeeds_if_only_fin_ack_dropped() {
     let recv_one = Arc::clone(&recv);
     let recv_one_handle = tokio::spawn(async move {
         recv_one
-            .accept_with_cid(recv_cid, conn_config)
+            .accept_with_cid(recv_cid, Peer::new_id(recv_cid.peer_id), conn_config)
             .await
             .unwrap()
     });
@@ -188,7 +189,7 @@ async fn close_succeeds_if_only_fin_ack_dropped() {
     let send_one = Arc::clone(&send);
     let send_one_handle = tokio::spawn(async move {
         send_one
-            .connect_with_cid(send_cid, conn_config)
+            .connect_with_cid(send_cid, Peer::new_id(send_cid.peer_id), conn_config)
             .await
             .unwrap()
     });


### PR DESCRIPTION
This PR allows `ConnectionPeer` to expose `PeerId` type and merge function.

This allows utp library to not require Peer object itself, but only PeerId object.

If multiple peer objects are provided for the same connection, they will be merged together and passed during `AsyncUdpSocket::send_to`.

The https://github.com/ethereum/trin/pull/1652 exposes how this works within trin client.

Note: I updated circleci rust version to 1.81.0 because old version was complaining about "Associated type bounds" syntax [`P: ConnectionPeer<Id: Unpin> + Unpin + 'static`](https://github.com/ethereum/utp/blob/16087be7139fc9827741cc4f23fdca061252bf50/src/socket.rs#L63)