### PR TITLE
test: 10 transfers of 100MB each

### DIFF
--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -15,21 +15,21 @@ const HUGE_TEST_DATA: &[u8] = &[0xf0; 100_000_000];
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
 async fn many_concurrent_transfers() {
-    concurrent_transfers(1000, TEST_DATA).await;
+    concurrent_transfers(1000, TEST_DATA, 3400).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
 async fn huge_concurrent_transfers() {
-    concurrent_transfers(100, HUGE_TEST_DATA).await;
+    concurrent_transfers(10, HUGE_TEST_DATA, 3406).await;
 }
 
-async fn concurrent_transfers(num_transfers: u16, data: &'static [u8]) {
+async fn concurrent_transfers(num_transfers: u16, data: &'static [u8], port: u16) {
     let _ = tracing_subscriber::fmt::try_init();
 
     tracing::info!("starting socket test");
 
-    let recv_addr = SocketAddr::from(([127, 0, 0, 1], 3400));
-    let send_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
+    let recv_addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let send_addr = SocketAddr::from(([127, 0, 0, 1], port + 1));
 
     let recv = UtpSocket::bind(recv_addr).await.unwrap();
     let recv = Arc::new(recv);


### PR DESCRIPTION
Performance and correctness seems to struggle with larger transfers.

This is known to fail locally, likely because of reasons detailed here: https://github.com/ethereum/utp/issues/138#issuecomment-2652808820

See the related https://github.com/ethereum/utp/pull/60 -- which is another worthwhile test to run. I'm specifically interested in using this test to find out whether concurrency with large data causes other distinct problems.