### PR TITLE
fix: clipped data bug after SYN->STATE packet drop

### DIFF
--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -9,32 +9,48 @@ use crate::cid::ConnectionId;
 use crate::peer::{ConnectionPeer, Peer};
 use crate::udp::AsyncUdpSocket;
 
+/// Decides whether the link between peers is up or down.
+trait LinkDecider {
+    /// Returns true if the link should send the packet, false otherwise.
+    ///
+    /// This must only be called once per packet, as it may have side-effects.
+    fn should_send(&mut self) -> bool;
+}
+
 /// A mock socket that can be used to simulate a perfect link.
 #[derive(Debug)]
-pub struct MockUdpSocket {
+pub struct MockUdpSocket<Link> {
     outbound: mpsc::UnboundedSender<Vec<u8>>,
     inbound: mpsc::UnboundedReceiver<Vec<u8>>,
     /// Peers identified by a letter
     pub only_peer: char,
     /// Defines whether the link is up. If not up, link will SILENTLY drop all sent packets.
-    up_status: Arc<AtomicBool>,
+    pub link: Link,
 }
 
-impl MockUdpSocket {
-    /// Get a network status controller for this socket.
-    /// In order to simulate a down link, store a false value into the status.
-    pub fn up_status(&mut self) -> Arc<AtomicBool> {
-        self.up_status.clone()
-    }
+#[derive(Clone)]
+pub struct ManualLinkDecider {
+    pub up_switch: Arc<AtomicBool>,
+}
 
-    /// Should the link send packets?
-    fn is_up(&self) -> bool {
-        self.up_status.load(Ordering::SeqCst)
+impl ManualLinkDecider {
+    fn new() -> Self {
+        Self {
+            up_switch: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}
+
+impl LinkDecider for ManualLinkDecider {
+    fn should_send(&mut self) -> bool {
+        self.up_switch.load(Ordering::SeqCst)
     }
 }
 
 #[async_trait]
-impl AsyncUdpSocket<char> for MockUdpSocket {
+impl<Link: LinkDecider + std::marker::Sync + std::marker::Send> AsyncUdpSocket<char>
+    for MockUdpSocket<Link>
+{
     /// # Panics
     ///
     /// Panics if `target` is not equal to `self.only_peer`. This socket is built to support
@@ -43,7 +59,8 @@ impl AsyncUdpSocket<char> for MockUdpSocket {
         if peer.id() != &self.only_peer {
             panic!("MockUdpSocket only supports sending to one peer");
         }
-        if !self.is_up() {
+        if !self.link.should_send() {
+            tracing::warn!("Dropping packet to {peer:?}: {buf:?}");
             return Ok(buf.len());
         }
         if let Err(err) = self.outbound.send(buf.to_vec()) {
@@ -87,7 +104,10 @@ impl ConnectionPeer for char {
     }
 }
 
-fn build_link_pair() -> (MockUdpSocket, MockUdpSocket) {
+fn build_link_pair<LinkAtoB, LinkBtoA>(
+    a_to_b_link: LinkAtoB,
+    b_to_a_link: LinkBtoA,
+) -> (MockUdpSocket<LinkAtoB>, MockUdpSocket<LinkBtoA>) {
     let (peer_a, peer_b): (char, char) = ('A', 'B');
     let (a_tx, a_rx) = mpsc::unbounded_channel();
     let (b_tx, b_rx) = mpsc::unbounded_channel();
@@ -95,27 +115,27 @@ fn build_link_pair() -> (MockUdpSocket, MockUdpSocket) {
         outbound: a_tx,
         inbound: b_rx,
         only_peer: peer_b,
-        up_status: Arc::new(AtomicBool::new(true)),
+        link: a_to_b_link,
     };
     let b = MockUdpSocket {
         outbound: b_tx,
         inbound: a_rx,
         only_peer: peer_a,
-        up_status: Arc::new(AtomicBool::new(true)),
+        link: b_to_a_link,
     };
     (a, b)
 }
 
-fn build_connection_id_pair(
-    socket_a: &MockUdpSocket,
-    socket_b: &MockUdpSocket,
+fn build_connection_id_pair<LinkAtoB, LinkBtoA>(
+    socket_a: &MockUdpSocket<LinkAtoB>,
+    socket_b: &MockUdpSocket<LinkBtoA>,
 ) -> (ConnectionId<char>, ConnectionId<char>) {
     build_connection_id_pair_starting_at(socket_a, socket_b, 100)
 }
 
-fn build_connection_id_pair_starting_at(
-    socket_a: &MockUdpSocket,
-    socket_b: &MockUdpSocket,
+fn build_connection_id_pair_starting_at<LinkAtoB, LinkBtoA>(
+    socket_a: &MockUdpSocket<LinkAtoB>,
+    socket_b: &MockUdpSocket<LinkBtoA>,
     lower_id: u16,
 ) -> (ConnectionId<char>, ConnectionId<char>) {
     let higher_id = lower_id.wrapping_add(1);
@@ -132,11 +152,13 @@ fn build_connection_id_pair_starting_at(
     (a_cid, b_cid)
 }
 
-pub fn build_connected_pair() -> (
-    (MockUdpSocket, ConnectionId<char>),
-    (MockUdpSocket, ConnectionId<char>),
+/// Build a link between sockets, which we can manually control whether it is up or down
+#[allow(clippy::type_complexity)]
+pub fn build_manually_linked_pair() -> (
+    (MockUdpSocket<ManualLinkDecider>, ConnectionId<char>),
+    (MockUdpSocket<ManualLinkDecider>, ConnectionId<char>),
 ) {
-    let (socket_a, socket_b) = build_link_pair();
+    let (socket_a, socket_b) = build_link_pair(ManualLinkDecider::new(), ManualLinkDecider::new());
     let (a_cid, b_cid) = build_connection_id_pair(&socket_a, &socket_b);
     ((socket_a, a_cid), (socket_b, b_cid))
 }


### PR DESCRIPTION
Fix #152 

The quick background is found in the link above. I expect it to be easier to review each commit separately.